### PR TITLE
Move all views to blueprints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 __pycache__/
-secret
-test.db
+*.db
 *.pyc
+uploads
+secret

--- a/app.py
+++ b/app.py
@@ -1,232 +1,31 @@
-import datetime
-import random
+from flask import render_template
 
-from flask import request, render_template, redirect, url_for, send_from_directory, session, flash
-from flask_restful import reqparse
-from markdown import markdown
-from werkzeug.security import check_password_hash
-
-from model.Board import Board
+from blueprints.boards import boards_blueprint
+from blueprints.main import main_blueprint
+from blueprints.slip import slip_blueprint
+from blueprints.threads import threads_blueprint
+from blueprints.upload import upload_blueprint
 from model.BoardCatalogResource import BoardCatalogResource
-from model.BoardList import BoardList
-from model.BoardListCatalog import BoardCatalog
 from model.BoardListResource import BoardListResource
-from model.Firehose import Firehose
 from model.FirehoseResource import FirehoseResource
-from model.Media import Media
-from model.NewPost import NewPost
 from model.NewPostResource import NewPostResource
-from model.NewThread import NewThread
 from model.NewThreadResource import NewThreadResource
-from model.Post import render_for_catalog, render_for_threads
-from model.PostReplyPattern import url_for_post
-from model.Poster import Poster
-from model.Session import Session
-from model.Slip import Slip, gen_slip, make_session, get_slip, slip_from_id
-from model.SubmissionError import SubmissionError
-from model.Tag import Tag
-from model.Thread import Thread
-from model.ThreadPosts import ThreadPosts
 from model.ThreadPostsResource import ThreadPostsResource
-from shared import db, app, rest_api
-
-rest_api.add_resource(NewPostResource, "/api/v1/thread/<int:thread_id>/new")
+from shared import app, rest_api
 
 
-@app.route("/thread/<int:thread_id>/new")
-def new_post(thread_id):
-    return render_template("new-post.html", thread_id=thread_id)
-
-
-@app.route("/thread/<int:thread_id>/new", methods=["POST"])
-def post_submit(thread_id):
-    NewPost().post(thread_id)
-    return redirect(url_for("view_thread", thread_id=thread_id) + "#thread-bottom")
-
-
-app.jinja_env.globals["get_slip"] = get_slip
-
-app.jinja_env.globals["slip_from_id"] = slip_from_id
-
-
-@app.route("/slip")
-def slip_landing():
-    return render_template("slip.html")
-
-
-@app.route("/slip-request", methods=["POST"])
-def slip_request():
-    name = request.form["name"]
-    password = request.form["password"]
-    slip = gen_slip(name, password)
-    make_session(slip)
-    return redirect(url_for("slip_landing"))
-
-
-@app.route("/slip-login", methods=["POST"])
-def slip_login():
-    form_name = request.form["name"]
-    password = request.form["password"]
-    slip = db.session.query(Slip).filter(Slip.name == form_name).one_or_none()
-    if slip:
-        if check_password_hash(slip.pass_hash, password):
-            make_session(slip)
-        else:
-            flash("Incorrect username or password!")
-    else:
-        flash("Incorrect username or password!")
-    return redirect(url_for("slip_landing"))
-
-
-@app.route("/unset-slip")
-def unset_slip():
-    if session.get("session-id"):
-        session_id = session["session-id"]
-        user_session = db.session.query(Session).filter(Session.id.like(session_id)).one()
-        db.session.delete(user_session)
-        db.session.commit()
-        session.pop("session-id")
-    return redirect(url_for("slip_landing"))
-
-
-@app.route("/upload/<int:media_id>")
-def uploaded_file(media_id):
-    media = db.session.query(Media).filter(Media.id == media_id).one()
-    return send_from_directory(app.config["UPLOAD_FOLDER"], "%d.%s" % (media.id, media.ext),
-                               last_modified=datetime.datetime.now())
-
-
-@app.route("/upload/thumb/<int:media_id>")
-def uploaded_thumb(media_id):
-    thumb_dir = app.config["THUMB_FOLDER"]
-    return send_from_directory(thumb_dir, "%d.jpg" % media_id,
-                               last_modified=datetime.datetime.now())
-
-
-def style_for_tag(tag_name):
-    tag = db.session.query(Tag).filter(Tag.name == tag_name).one()
-    return {"bg_style": tag.bg_style, "text_style": tag.text_style}
-
-
-app.jinja_env.globals["style_for_tag"] = style_for_tag
-
-rest_api.add_resource(ThreadPostsResource, "/api/v1/thread/<int:thread_id>")
-
-app.jinja_env.globals["url_for_post"] = url_for_post
-
-
-@app.route("/thread/<int:thread_id>")
-def view_thread(thread_id):
-    posts = ThreadPosts().retrieve(thread_id)
-    render_for_threads(posts)
-    thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
-    thread.views += 1
-    db.session.add(thread)
-    db.session.commit()
-    board_id = thread.board
-    num_posters = db.session.query(Poster).filter(Poster.thread == thread_id).count()
-    num_media = thread.num_media()
-    return render_template("thread.html", thread_id=thread_id, board_id=board_id, posts=posts, num_views=thread.views,
-                           num_media=num_media, num_posters=num_posters)
-
-
-@app.route("/thread/<int:thread_id>/gallery")
-def view_gallery(thread_id):
-    posts = ThreadPosts().retrieve(thread_id)
-    thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
-    board_id = thread.board
-    return render_template("gallery.html", thread_id=thread_id, board_id=board_id, posts=posts)
-
-
-rest_api.add_resource(NewThreadResource, "/api/v1/thread/new")
-
-
-@app.route("/thread/new/<int:board_id>")
-def new_thread(board_id):
-    return render_template("new-thread.html", board_id=board_id)
-
-
-@app.route("/thread/new", methods=["POST"])
-def thread_submit():
-    try:
-        thread = NewThread().post_impl()
-        return redirect(url_for("view_thread", thread_id=thread.id))
-    except SubmissionError as e:
-        flash(str(e.args[0]))
-        return redirect(url_for("new_thread", board_id=e.args[1]))
-
-
-def gen_poster_id():
-    id_chars = "ABCDEF0123456789"
-    return ''.join(random.sample(id_chars, 4))
-
+app.register_blueprint(main_blueprint, url_prefix='/')
+app.register_blueprint(boards_blueprint, url_prefix='/boards')
+app.register_blueprint(threads_blueprint, url_prefix='/threads')
+app.register_blueprint(upload_blueprint, url_prefix='/upload')
+app.register_blueprint(slip_blueprint, url_prefix='/slip')
 
 rest_api.add_resource(BoardListResource, "/api/v1/boards/")
-
-
-@app.route("/boards")
-def list_boards():
-    return render_template("board-index.html", boards=BoardList().get())
-
-
 rest_api.add_resource(BoardCatalogResource, "/api/v1/board/<int:board_id>/catalog")
-
-
-@app.route("/board/<int:board_id>")
-def view_catalog(board_id):
-    threads = BoardCatalog().retrieve(board_id)
-    board_name = db.session.query(Board).filter(Board.id == board_id).one().name
-    render_for_catalog(threads)
-    return render_template("catalog.html", threads=threads, board_id=board_id, board_name=board_name)
-
-
-@app.route("/rules")
-@app.route("/board/<int:board_id>/rules")
-def view_rules(board_id=None):
-    if board_id:
-        board = db.session.query(Board).filter(Board.id == board_id).one()
-        return render_template("rules.html", board=board, markdown=markdown)
-    return render_template("rules.html", markdown=markdown)
-
-
-@app.route("/board/<int:board_id>/admin")
-def board_admin(board_id):
-    if get_slip() and get_slip().is_admin:
-        board = db.session.query(Board).filter(Board.id == board_id).one()
-        return render_template("board-admin.html", board=board)
-    else:
-        flash("Only admins can access board administration!")
-        return redirect(url_for("view_catalog", board_id=board_id))
-
-
-@app.route("/board/<int:board_id>/admin", methods=["POST"])
-def board_admin_update(board_id):
-    if get_slip() is None or get_slip().is_admin is False:
-        flash("Only admins can access board administration!")
-        return redirect(url_for("view_catalog", board_id=board_id))
-    board = db.session.query(Board).filter(Board.id == board_id).one()
-    parser = reqparse.RequestParser()
-    parser.add_argument("name", type=str, required=True)
-    parser.add_argument("rules", type=str, required=True)
-    args = parser.parse_args()
-    board.name = args["name"]
-    board.rules = args["rules"]
-    db.session.add(board)
-    db.session.commit()
-    return redirect(url_for("view_catalog", board_id=board_id))
-
-
-@app.route("/faq")
-def faq():
-    return render_template("faq.html")
-
-
+rest_api.add_resource(ThreadPostsResource, "/api/v1/thread/<int:thread_id>")
+rest_api.add_resource(NewThreadResource, "/api/v1/thread/new")
+rest_api.add_resource(NewPostResource, "/api/v1/thread/<int:thread_id>/new")
 rest_api.add_resource(FirehoseResource, "/api/v1/firehose")
-
-
-@app.route("/")
-def index():
-    return render_template("index.html", threads=Firehose().get_impl())
 
 
 @app.errorhandler(404)

--- a/blueprints/boards.py
+++ b/blueprints/boards.py
@@ -1,0 +1,69 @@
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_restful import reqparse
+from markdown import markdown
+
+from model.Board import Board
+from model.BoardList import BoardList
+from model.BoardListCatalog import BoardCatalog
+from model.Post import render_for_catalog
+from model.Slip import get_slip
+from model.Tag import Tag
+from shared import db
+
+
+def style_for_tag(tag_name):
+    tag = db.session.query(Tag).filter(Tag.name == tag_name).one()
+    return {"bg_style": tag.bg_style, "text_style": tag.text_style}
+
+
+boards_blueprint = Blueprint('boards', __name__, template_folder='template')
+boards_blueprint.add_app_template_global(style_for_tag)
+
+
+@boards_blueprint.route("/")
+def list():
+    return render_template("board-index.html", boards=BoardList().get())
+
+
+@boards_blueprint.route("/<int:board_id>")
+def catalog(board_id):
+    threads = BoardCatalog().retrieve(board_id)
+    board_name = db.session.query(Board).filter(Board.id == board_id).one().name
+    render_for_catalog(threads)
+    return render_template("catalog.html", threads=threads, board_id=board_id, board_name=board_name)
+
+
+@boards_blueprint.route("/rules", defaults={'board_id': None})
+@boards_blueprint.route("/rules/<int:board_id>")
+def rules(board_id):
+    if board_id is None:
+        return redirect(url_for('main.rules'))
+    board = db.session.query(Board).filter(Board.id == board_id).one()
+    return render_template("rules.html", board=board, markdown=markdown)
+
+
+@boards_blueprint.route("/admin/<int:board_id>")
+def admin(board_id):
+    if get_slip() and get_slip().is_admin:
+        board = db.session.query(Board).filter(Board.id == board_id).one()
+        return render_template("board-admin.html", board=board)
+    else:
+        flash("Only admins can access board administration!")
+        return redirect(url_for("boards.catalog", board_id=board_id))
+
+
+@boards_blueprint.route("/admin/<int:board_id>", methods=["POST"])
+def admin_update(board_id):
+    if get_slip() is None or get_slip().is_admin is False:
+        flash("Only admins can access board administration!")
+        return redirect(url_for("boards.catalog", board_id=board_id))
+    board = db.session.query(Board).filter(Board.id == board_id).one()
+    parser = reqparse.RequestParser()
+    parser.add_argument("name", type=str, required=True)
+    parser.add_argument("rules", type=str, required=True)
+    args = parser.parse_args()
+    board.name = args["name"]
+    board.rules = args["rules"]
+    db.session.add(board)
+    db.session.commit()
+    return redirect(url_for("boards.catalog", board_id=board_id))

--- a/blueprints/main.py
+++ b/blueprints/main.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, render_template
+from markdown import markdown
+
+from model.Firehose import Firehose
+
+
+main_blueprint = Blueprint('main', __name__, template_folder='template')
+
+
+@main_blueprint.route("/")
+def index():
+    return render_template("index.html", threads=Firehose().get_impl())
+
+
+@main_blueprint.route("/rules")
+def rules():
+    return render_template("rules.html", markdown=markdown)
+
+
+@main_blueprint.route("/faq")
+def faq():
+    return render_template("faq.html")

--- a/blueprints/slip.py
+++ b/blueprints/slip.py
@@ -1,0 +1,51 @@
+from flask import Blueprint, request, render_template, redirect, url_for, session, flash
+from werkzeug.security import check_password_hash
+
+from model.Session import Session
+from model.Slip import Slip, gen_slip, make_session, get_slip, slip_from_id
+from shared import db
+
+
+slip_blueprint = Blueprint('slip', __name__, template_folder='template')
+slip_blueprint.add_app_template_global(get_slip)
+slip_blueprint.add_app_template_global(slip_from_id)
+
+
+@slip_blueprint.route("/")
+def landing():
+    return render_template("slip.html")
+
+
+@slip_blueprint.route("/register", methods=["POST"])
+def register():
+    name = request.form["name"]
+    password = request.form["password"]
+    slip = gen_slip(name, password)
+    make_session(slip)
+    return redirect(url_for("slip.landing"))
+
+
+@slip_blueprint.route("/login", methods=["POST"])
+def login():
+    form_name = request.form["name"]
+    password = request.form["password"]
+    slip = db.session.query(Slip).filter(Slip.name == form_name).one_or_none()
+    if slip:
+        if check_password_hash(slip.pass_hash, password):
+            make_session(slip)
+        else:
+            flash("Incorrect username or password!")
+    else:
+        flash("Incorrect username or password!")
+    return redirect(url_for("slip.landing"))
+
+
+@slip_blueprint.route("/unset")
+def unset():
+    if session.get("session-id"):
+        session_id = session["session-id"]
+        user_session = db.session.query(Session).filter(Session.id.like(session_id)).one()
+        db.session.delete(user_session)
+        db.session.commit()
+        session.pop("session-id")
+    return redirect(url_for("slip.landing"))

--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -1,0 +1,64 @@
+from flask import Blueprint, render_template, redirect, url_for, flash
+
+from model.NewPost import NewPost
+from model.NewThread import NewThread
+from model.Post import render_for_threads
+from model.PostReplyPattern import url_for_post
+from model.Poster import Poster
+from model.SubmissionError import SubmissionError
+from model.Thread import Thread
+from model.ThreadPosts import ThreadPosts
+from shared import db
+
+
+threads_blueprint = Blueprint('threads', __name__, template_folder='template')
+threads_blueprint.add_app_template_global(url_for_post)
+
+
+@threads_blueprint.route("/new/<int:board_id>")
+def new(board_id):
+    return render_template("new-thread.html", board_id=board_id)
+
+
+@threads_blueprint.route("/new", methods=["POST"])
+def submit():
+    try:
+        thread = NewThread().post_impl()
+        return redirect(url_for("threads.view", thread_id=thread.id))
+    except SubmissionError as e:
+        flash(str(e.args[0]))
+        return redirect(url_for("threads.new", board_id=e.args[1]))
+
+
+@threads_blueprint.route("/<int:thread_id>")
+def view(thread_id):
+    posts = ThreadPosts().retrieve(thread_id)
+    render_for_threads(posts)
+    thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
+    thread.views += 1
+    db.session.add(thread)
+    db.session.commit()
+    board_id = thread.board
+    num_posters = db.session.query(Poster).filter(Poster.thread == thread_id).count()
+    num_media = thread.num_media()
+    return render_template("thread.html", thread_id=thread_id, board_id=board_id, posts=posts, num_views=thread.views,
+                           num_media=num_media, num_posters=num_posters)
+
+
+@threads_blueprint.route("/<int:thread_id>/new")
+def new_post(thread_id):
+    return render_template("new-post.html", thread_id=thread_id)
+
+
+@threads_blueprint.route("/<int:thread_id>/new", methods=["POST"])
+def post_submit(thread_id):
+    NewPost().post(thread_id)
+    return redirect(url_for("threads.view", thread_id=thread_id) + "#thread-bottom")
+
+
+@threads_blueprint.route("/<int:thread_id>/gallery")
+def view_gallery(thread_id):
+    posts = ThreadPosts().retrieve(thread_id)
+    thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
+    board_id = thread.board
+    return render_template("gallery.html", thread_id=thread_id, board_id=board_id, posts=posts)

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -1,0 +1,23 @@
+import datetime
+
+from flask import Blueprint, current_app, send_from_directory
+
+from model.Media import Media
+from shared import db
+
+
+upload_blueprint = Blueprint('upload', __name__, template_folder='template')
+
+
+@upload_blueprint.route("/<int:media_id>")
+def file(media_id):
+    media = db.session.query(Media).filter(Media.id == media_id).one()
+    return send_from_directory(current_app.config["UPLOAD_FOLDER"], "%d.%s" % (media.id, media.ext),
+                               last_modified=datetime.datetime.now())
+
+
+@upload_blueprint.route("/thumb/<int:media_id>")
+def thumb(media_id):
+    thumb_dir = current_app.config["THUMB_FOLDER"]
+    return send_from_directory(thumb_dir, "%d.jpg" % media_id,
+                               last_modified=datetime.datetime.now())

--- a/model/NewPost.py
+++ b/model/NewPost.py
@@ -2,7 +2,7 @@ import os
 import re
 
 from PIL import Image
-from flask import request
+from flask import current_app, request
 from flask_restful import reqparse, inputs
 
 from model.Media import Media
@@ -11,7 +11,7 @@ from model.Post import Post
 from model.Reply import Reply, REPLY_REGEXP
 from model.Thread import Thread
 from model.Slip import get_slip
-from shared import app, db, ip_to_int, gen_poster_id
+from shared import db, ip_to_int, gen_poster_id
 
 
 class NewPost:
@@ -47,7 +47,7 @@ class NewPost:
             db.session.add(media)
             db.session.commit()
             media_id = media.id
-            full_path = os.path.join(app.config["UPLOAD_FOLDER"], "%d.%s" % (media_id, file_ext))
+            full_path = os.path.join(current_app.config["UPLOAD_FOLDER"], "%d.%s" % (media_id, file_ext))
             uploaded_file.save(full_path)
             if file_ext != "webm":
                 # non-webm thumbnail generation
@@ -66,7 +66,7 @@ class NewPost:
                 new_width = int(thumb.width * scale_factor)
                 new_height = int(thumb.height * scale_factor)
                 thumb = thumb.resize((new_width, new_height), Image.LANCZOS)
-                thumb.convert("RGB").save(os.path.join(app.config["THUMB_FOLDER"], "%d.jpg" % media_id), "JPEG")
+                thumb.convert("RGB").save(os.path.join(current_app.config["THUMB_FOLDER"], "%d.jpg" % media_id), "JPEG")
             else:
                 # FIXME: webm thumbnail generation
                 pass

--- a/model/PostReplyPattern.py
+++ b/model/PostReplyPattern.py
@@ -10,7 +10,7 @@ from model.Reply import REPLY_REGEXP
 def url_for_post(post_id):
     from model.Thread import Thread
     thread = Thread.query.filter(Thread.posts.any(id=post_id)).one()
-    return url_for("view_thread", thread_id=thread.id) + "#" + str(post_id)
+    return url_for("threads.view", thread_id=thread.id) + "#" + str(post_id)
 
 
 class PostReplyPattern(Pattern):

--- a/shared.py
+++ b/shared.py
@@ -6,7 +6,6 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_restful import Api
 
 app = Flask(__name__)
-app.config["DEBUG"] = True
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///test.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["UPLOAD_FOLDER"] = "./uploads"

--- a/shared.py
+++ b/shared.py
@@ -3,23 +3,31 @@ import random
 from customjsonencoder import CustomJSONEncoder
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from flask_restful import Resource, Api, reqparse, inputs
+from flask_restful import Api
 
 app = Flask(__name__)
+app.config["DEBUG"] = True
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///test.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["UPLOAD_FOLDER"] = "./uploads"
 app.config["THUMB_FOLDER"] = os.path.join(app.config["UPLOAD_FOLDER"], "thumb")
+app.url_map.strict_slashes = False
 app.json_encoder = CustomJSONEncoder
 db = SQLAlchemy(app)
 rest_api = Api(app)
+
+
 def get_secret():
     return open("secret").read()
+
+
 app.secret_key = get_secret()
+
 
 def gen_poster_id():
     id_chars = "ABCDEF0123456789"
     return ''.join(random.sample(id_chars, 4))
+
 
 def ip_to_int(ip_str):
     # TODO: IPv6 support

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,7 +29,7 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top mb-2">
-    <a class="navbar-brand" href="{{ url_for("index") }}">Maniwani</a>
+    <a class="navbar-brand" href="{{ url_for("main.index") }}">Maniwani</a>
     <script>
 			 document.write('<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-nav"> \
 				 <span class="navbar-toggler-icon"></span> \
@@ -40,16 +40,16 @@
     </script>
     <div id="site-nav" class="navbar-nav">
         {% block navbar %}{% endblock %}
-        <a href="{{ url_for("list_boards") }}" class="nav-item nav-link">Boards</a>
-        <a href="{{ url_for("slip_landing") }}" class="nav-item nav-link">Slip</a>
+        <a href="{{ url_for("boards.list") }}" class="nav-item nav-link">Boards</a>
+        <a href="{{ url_for("slip.landing") }}" class="nav-item nav-link">Slip</a>
         {% if board_id is not defined and board is not defined %}
-        <a href="{{ url_for("view_rules") }}" class="nav-item nav-link">Rules</a>
+        <a href="{{ url_for("main.rules") }}" class="nav-item nav-link">Rules</a>
         {% elif board_id is defined %}
-        <a href="{{ url_for("view_rules", board_id=board_id) }}" class="nav-item nav-link">Rules</a>
+        <a href="{{ url_for("boards.rules", board_id=board_id) }}" class="nav-item nav-link">Rules</a>
         {% else %}
-        <a href="{{ url_for("view_rules", board_id=board.id) }}" class="nav-item nav-link">Rules</a>
+        <a href="{{ url_for("boards.rules", board_id=board.id) }}" class="nav-item nav-link">Rules</a>
         {% endif %}
-        <a href="{{ url_for("faq") }}" class="nav-item nav-link">FAQ</a>
+        <a href="{{ url_for("main.faq") }}" class="nav-item nav-link">FAQ</a>
         <div class="navbar-nav ml-auto">
             {% block navbar_right %}{% endblock %}
         </div>

--- a/templates/board-index.html
+++ b/templates/board-index.html
@@ -67,10 +67,10 @@ board index
 
         </script>
         {% for board in boards %}
-        <a href="{{ url_for("view_catalog", board_id=board["id"]) }}" class="board bg-light border rounded">
+        <a href="{{ url_for("boards.catalog", board_id=board["id"]) }}" class="board bg-light border rounded">
         <div class="board-container">
             {% if board["media"] %}
-            <img src="{{ url_for("uploaded_thumb", media_id=board["media"]) }}" class="board-media img-fluid">
+            <img src="{{ url_for("upload.thumb", media_id=board["media"]) }}" class="board-media img-fluid">
             <span class="board-name over-image text-dark">/{{ board["name"] }}/</span>
             {% else %}
             <div class="dummy-media"></div>

--- a/templates/catalog-view.html
+++ b/templates/catalog-view.html
@@ -55,8 +55,8 @@
         {% endif %}
         <div class="thread border-top rounded">
             {% if thread["media"] %}
-            <a href="{{ url_for("view_thread", thread_id=thread["id"]) }}">
-            <img class="border-left border-right w-100 rounded-top" src="{{ url_for("uploaded_thumb",
+            <a href="{{ url_for("threads.view", thread_id=thread["id"]) }}">
+            <img class="border-left border-right w-100 rounded-top" src="{{ url_for("upload.thumb",
             media_id=thread["media"]) }}">
             </a>
             {% endif %}
@@ -75,7 +75,7 @@
         </div>
         <div class="{{ "pt-1 border border-top-0 rounded-bottom
         " + ns.bg_style }}">
-        <a href="{{ url_for("view_thread", thread_id=thread["id"]) }}" class="btn btn-dark m-2">View thread</a>
+        <a href="{{ url_for("threads.view", thread_id=thread["id"]) }}" class="btn btn-dark m-2">View thread</a>
         <span class="{{ "mt-3 mr-2 float-right " + ns.text_style }}">
         <i class="fas fa-comment"></i> {{ thread["num_replies"] }}
         <i class="fas fa-image"></i> {{ thread["num_media"] }}

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -3,9 +3,9 @@
 /{{ board_name }}/ catalog
 {% endblock %}
 {% block navbar %}
-<a href="{{ url_for("new_thread", board_id=board_id) }}" class="nav-item nav-link">New thread</a>
+<a href="{{ url_for("threads.new", board_id=board_id) }}" class="nav-item nav-link">New thread</a>
 {% if get_slip() and get_slip().is_admin %}
-<a href="{{ url_for("board_admin", board_id=board_id) }}" class="nav-item nav-link">Admin</a>
+<a href="{{ url_for("boards.admin", board_id=board_id) }}" class="nav-item nav-link">Admin</a>
 {% endif %}
 {% endblock %}
 {% block content %}

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -42,7 +42,7 @@ frequently asked questions
         can do, in addition to gracefully downgrading if Javascript has been disabled.</p>
     <h1 id="what-topics">What topics can I talk about here?</h1>
     <p class="lead">Plenty!</p>
-    <p>Go look at the <a href="{{ url_for("list_boards") }}">board listing</a> to get an idea of the sort of
+    <p>Go look at the <a href="{{ url_for("boards.list") }}">board listing</a> to get an idea of the sort of
         things you can talk about.</p>
 </div>
 {% endblock %}

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -36,8 +36,8 @@ media gallery
 <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
 {% endblock %}
 {% block navbar %}
-<a href="{{ url_for("view_thread", thread_id=thread_id) }}" class="nav-item nav-link">Back to thread</a>
-<a href="{{ url_for("view_catalog", board_id=board_id) }}" class="nav-item nav-link">Catalog</a>
+<a href="{{ url_for("threads.view", thread_id=thread_id) }}" class="nav-item nav-link">Back to thread</a>
+<a href="{{ url_for("boards.catalog", board_id=board_id) }}" class="nav-item nav-link">Catalog</a>
 {% endblock %}
 {% block content %}
 <div class="container-fluid">
@@ -51,8 +51,8 @@ media gallery
         {% for post in posts %}
         {% if post["media"] %}
         <div class="gallery-entry">
-            <a href="{{ url_for("uploaded_file", media_id=post["media"]) }}">
-            <img class="img-fluid img-thumbnail" src="{{ url_for("uploaded_thumb", media_id=post["media"]) }}">
+            <a href="{{ url_for("upload.file", media_id=post["media"]) }}">
+            <img class="img-fluid img-thumbnail" src="{{ url_for("upload.thumb", media_id=post["media"]) }}">
             </a>
             {% if post["media_ext"] in ["gif", "webm"] %}
             <small class="text-muted">Animated - click to play</small>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,9 +8,9 @@
             <p class="lead">An anonymous imageboard for the 21st century</p>
             <hr class="my-4">
             <p>If you're not sure what an imageboard is, or why you'd want to use one,
-                check out the <a href="{{ url_for("faq") + "#whats-an-imageboard" }}">FAQ</a>.
+                check out the <a href="{{ url_for("main.faq") + "#whats-an-imageboard" }}">FAQ</a>.
                 If you already know what an imageboard is, but aren't quite aware of what
-                Maniwani brings to the table, there's another <a href="{{ url_for("faq") + "#why-maniwani" }}">FAQ
+                Maniwani brings to the table, there's another <a href="{{ url_for("main.faq") + "#why-maniwani" }}">FAQ
                 entry</a>
                 that should help you out. If you want to dive right in, you can see the most
                 recently-updated threads on the site below.</p>

--- a/templates/new-post.html
+++ b/templates/new-post.html
@@ -3,9 +3,9 @@
 <title>Maniwani - reply to thread</title>
 {% endblock %}
 {% block navbar %}
-<a href="{{ url_for(" view_thread", thread_id=thread_id) }}" class="nav-item nav-link">Back to thread</a>
+<a href="{{ url_for("threads.view", thread_id=thread_id) }}" class="nav-item nav-link">Back to thread</a>
 {% endblock %}
 {% import "post-base.html" as post %}
 {% block content %}
-{{ post.post_form(url_for("post_submit", thread_id=thread_id), "thread", thread_id) }}
+{{ post.post_form(url_for("threads.post_submit", thread_id=thread_id), "thread", thread_id) }}
 {% endblock %}

--- a/templates/new-thread.html
+++ b/templates/new-thread.html
@@ -3,11 +3,11 @@
 new thread
 {% endblock %}
 {% block navbar %}
-<a href="{{ url_for("view_catalog", board_id=board_id) }}" class="nav-item nav-link">Catalog</a>
+<a href="{{ url_for("boards.catalog", board_id=board_id) }}" class="nav-item nav-link">Catalog</a>
 {% endblock %}
 {% import "post-base.html" as post %}
 {% block content %}
 <div class="container">
-    {{ post.post_form(url_for("thread_submit"), "board", board_id, thread_op=True) }}
+    {{ post.post_form(url_for("threads.submit"), "board", board_id, thread_op=True) }}
 </div>
 {% endblock %}

--- a/templates/slip.html
+++ b/templates/slip.html
@@ -26,12 +26,12 @@ slip
             <label for="slipPassword">Password</label>
             <input type="password" class="form-control" id="slipPassword" name="password">
         </div>
-        <button type="submit" class="btn btn-primary" formaction="{{ url_for("slip_login") }}">Log in</button>
-        <button type="submit" class="btn btn-primary" formaction="{{ url_for("slip_request") }}">Sign up</button>
+        <button type="submit" class="btn btn-primary" formaction="{{ url_for("slip.login") }}">Log in</button>
+        <button type="submit" class="btn btn-primary" formaction="{{ url_for("slip.register") }}">Sign up</button>
     </form>
     {% else %}
     <p>Your slip is: <b>{{ get_slip().name }}</b></p>
-    <a href="{{ url_for("unset_slip") }}" class="btn btn-primary">Log out</a>
+    <a href="{{ url_for("slip.unset") }}" class="btn btn-primary">Log out</a>
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/thread.html
+++ b/templates/thread.html
@@ -23,7 +23,7 @@ view thread
 {% endblock %}
 {% block navbar %}
 <noscript>
-    <a href="{{ url_for("new_post", thread_id=thread_id) }}" class="nav-item nav-link">New post</a>
+    <a href="{{ url_for("threads.new_post", thread_id=thread_id) }}" class="nav-item nav-link">New post</a>
 </noscript>
 <script>
 	 document.write("<a href=\"#\" class=\"nav-item nav-link\" data-toggle=\"modal\" data-target=\"#replyModal\">New post</a>")
@@ -31,8 +31,8 @@ view thread
 
 
 </script>
-<a href="{{ url_for("view_gallery", thread_id=thread_id) }}" class="nav-item nav-link">Gallery</a>
-<a href="{{ url_for("view_catalog", board_id=board_id) }}" class="nav-item nav-link">Catalog</a>
+<a href="{{ url_for("threads.view_gallery", thread_id=thread_id) }}" class="nav-item nav-link">Gallery</a>
+<a href="{{ url_for("boards.catalog", board_id=board_id) }}" class="nav-item nav-link">Catalog</a>
 {% endblock %}
 {% block navbar_right %}
 <span class="navbar-item navbar-text">Views: <span class="text-light mr-1">{{ num_views }}</span></span>
@@ -48,7 +48,7 @@ view thread
             </div>
             <div class="modal-body">
                 {% import "post-base.html" as post %}
-                {{ post.post_form(url_for("post_submit", thread_id=thread_id), "thread", thread_id, False) }}
+                {{ post.post_form(url_for("threads.post_submit", thread_id=thread_id), "thread", thread_id, False) }}
             </div>
             <div class="modal-footer">
                 <button type="submit" class="btn btn-primary" form="postForm">Submit</button>
@@ -74,27 +74,27 @@ view thread
     {% if post["media"] %}
     {% if post["media_ext"] == "webm" %}
     <div class="col">
-        <a href="{{ url_for("uploaded_file", media_id=post["media"]) }}">
+        <a href="{{ url_for("upload.file", media_id=post["media"]) }}">
         <video style="width: 100%; max-width: 25em;">
-            <source src="{{ url_for("uploaded_file", media_id=post["media"]) }}" type="video/webm">
+            <source src="{{ url_for("upload.file", media_id=post["media"]) }}" type="video/webm">
         </video>
         </a>
     </div>
     {% else %}
     <div class="col">
         <div class="img-thumbnail" style="display: inline-block;">
-            <a href="{{ url_for("uploaded_file", media_id=post["media"]) }}" class="media-container">
+            <a href="{{ url_for("upload.file", media_id=post["media"]) }}" class="media-container">
             {% set ns = namespace(img_style="max-width: 15em; max-height: 20em;") %}
             {% if post["spoiler"] == True %}
             <span id="spoiler-label-{{ post["media"] }}" class="spoiler-label text-danger">!</span>
             {% set ns.img_style = ns.img_style + " opacity: 0.025;" %}
             {% endif %}
             {% if post["media_ext"] == "gif" %}
-            <img src="{{ url_for("uploaded_thumb", media_id=post["media"]) }}" data-full="{{ url_for("uploaded_file",
-            media_id=post["media"]) }}" data-thumb="{{ url_for("uploaded_thumb", media_id=post["media"]) }}" data-id="{{
+            <img src="{{ url_for("upload.thumb", media_id=post["media"]) }}" data-full="{{ url_for("upload.file",
+            media_id=post["media"]) }}" data-thumb="{{ url_for("upload.thumb", media_id=post["media"]) }}" data-id="{{
             post["media"] }}" class="img-animated" style="{{ ns.img_style }}">
             {% else %}
-            <img src="{{ url_for("uploaded_thumb", media_id=post["media"]) }}" style="{{ ns.img_style }}">
+            <img src="{{ url_for("upload.thumb", media_id=post["media"]) }}" style="{{ ns.img_style }}">
             {% endif %}
             </a>
         </div>


### PR DESCRIPTION
Since up to this point every view is defined in a single file (`app.py`) I propose a small cleanup and move all views to appropriate Flask blueprints. This should make the code base a bit easier to read and maintain.

I also propose to move Jinja2 globals to different blueprints and use `add_app_template_global` function to register them automatically rather than directly modifying `jinja_env.globals` dict.