### PR TITLE
faster gen_poster_id()

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -18,8 +18,7 @@ def get_secret():
 app.secret_key = get_secret()
 
 def gen_poster_id():
-    id_chars = "ABCDEF0123456789"
-    return ''.join(random.sample(id_chars, 4))
+    return '%04X' % random.randint(0, 0xffff)
 
 def ip_to_int(ip_str):
     # TODO: IPv6 support


### PR DESCRIPTION
Proposing faster `gen_poster_id()` implementation, since random sampling is slower than generating random integers.
Here's a simple script for CPU time comparison per single run (in microseconds):
```python
# gen_poster_id_test.py
import random
from timeit import timeit

def gen_poster_id_1():
    id_chars = "ABCDEF0123456789"
    return ''.join(random.sample(id_chars, 4))

def gen_poster_id_2():
    return '%04X' % random.randint(0, 0xffff)

number_of_passes = 1000000
gpi1_avg_time = timeit(gen_poster_id_1, number=number_of_passes) / float(number_of_passes)
gpi2_avg_time = timeit(gen_poster_id_2, number=number_of_passes) / float(number_of_passes)

print("gen_poster_id_1 avg time: %.2f us" % (gpi1_avg_time * 1e6))
print("gen_poster_id_2 avg time: %.2f us" % (gpi2_avg_time * 1e6))
```
Example output (run on Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz, single core):
```bash
$ python3 gen_poster_id_test.py
gen_poster_id_1 avg time: 4.10 us
gen_poster_id_2 avg time: 1.11 us
```