### PR TITLE
Add moderation

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from model.BoardListResource import BoardListResource
 from model.FirehoseResource import FirehoseResource
 from model.NewPostResource import NewPostResource
 from model.NewThreadResource import NewThreadResource
+from model.PostRemovalResource import PostRemovalResource
 from model.ThreadPostsResource import ThreadPostsResource
 from shared import app, rest_api
 
@@ -24,6 +25,7 @@ rest_api.add_resource(BoardListResource, "/api/v1/boards/")
 rest_api.add_resource(BoardCatalogResource, "/api/v1/board/<int:board_id>/catalog")
 rest_api.add_resource(ThreadPostsResource, "/api/v1/thread/<int:thread_id>")
 rest_api.add_resource(NewThreadResource, "/api/v1/thread/new")
+rest_api.add_resource(PostRemovalResource, "/api/v1/thread/post/<int:post_id>")
 rest_api.add_resource(NewPostResource, "/api/v1/thread/<int:thread_id>/new")
 rest_api.add_resource(FirehoseResource, "/api/v1/firehose")
 

--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -3,6 +3,7 @@ from flask import Blueprint, render_template, redirect, url_for, flash
 from model.NewPost import NewPost
 from model.NewThread import NewThread
 from model.Post import Post, render_for_threads
+from model.PostRemoval import PostRemoval
 from model.PostReplyPattern import url_for_post
 from model.Poster import Poster
 from model.Slip import get_slip
@@ -53,8 +54,7 @@ def delete(thread_id):
         return redirect(url_for("threads.view", thread_id=thread_id))
     thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
     board_id = thread.board
-    db.session.delete(thread)
-    db.session.commit()
+    ThreadPosts().delete(thread_id)
     flash("Thread deleted!")
     return redirect(url_for("boards.catalog", board_id=board_id))
 
@@ -75,10 +75,9 @@ def delete_post(post_id):
     if not get_slip() or not (get_slip().is_admin or get_slip().is_mod):
         flash("Only moderators and admins can delete threads!")
         return redirect(url_for_post(post_id))
-    post = db.session.query(Post).filter(Post.id == post_id).one()
-    thread_id = post.thread
-    db.session.delete(post)
-    db.session.commit()
+    thread = db.session.query(Thread).filter(Thread.posts.any(Post.id == post_id)).one()
+    thread_id = thread.id
+    PostRemoval().delete(post_id)
     flash("Post deleted!")
     return redirect(url_for("threads.view", thread_id=thread_id))
 

--- a/model/Post.py
+++ b/model/Post.py
@@ -27,5 +27,5 @@ class Post(OutputMixin, db.Model):
     thread = db.Column(db.Integer, db.ForeignKey("thread.id"), nullable=False)
     datetime = db.Column(db.DateTime, nullable=False, default=_datetime.datetime.utcnow)
     poster = db.Column(db.Integer, db.ForeignKey("poster.id"), nullable=False)
-    media = db.Column(db.Integer, db.ForeignKey("media.id"), nullable=True)
+    media = db.Column(db.Integer, db.ForeignKey("media.id", ondelete="CASCADE"), nullable=True)
     spoiler = db.Column(db.Boolean, nullable=True)

--- a/model/PostRemoval.py
+++ b/model/PostRemoval.py
@@ -1,0 +1,11 @@
+from model.Post import Post
+from shared import db
+
+
+class PostRemoval:
+    def delete(self, post_id):
+        post = db.session.query(Post).filter(Post.id == post_id).one()
+        thread_id = post.thread
+        # TODO: clean up attachments
+        db.session.delete(post)
+        db.session.commit()

--- a/model/PostRemovalResource.py
+++ b/model/PostRemovalResource.py
@@ -1,0 +1,6 @@
+from flask_restful import Resource
+from model.PostRemoval import PostRemoval
+
+
+class PostRemovalResource(PostRemoval, Resource):
+    pass

--- a/model/Poster.py
+++ b/model/Poster.py
@@ -5,5 +5,5 @@ class Poster(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     hex_string = db.Column(db.String(4), nullable=False)
     ip_address = db.Column(db.Integer, nullable=False)
-    thread = db.Column(db.Integer, db.ForeignKey("thread.id"), nullable=False)
+    thread = db.Column(db.Integer, db.ForeignKey("thread.id", ondelete="CASCADE"), nullable=False)
     slip = db.Column(db.Integer, db.ForeignKey("slip.id"), nullable=True)

--- a/model/Thread.py
+++ b/model/Thread.py
@@ -14,7 +14,7 @@ class Thread(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     board = db.Column(db.Integer, db.ForeignKey("board.id"), nullable=False)
     views = db.Column(db.Integer, nullable=False)
-    posts = relationship("Post", order_by=Post.datetime)
+    posts = relationship("Post", order_by=Post.datetime, cascade="delete")
     last_updated = db.Column(db.DateTime)
     tags = relationship("Tag", secondary=tags, lazy='subquery',
                         backref=db.backref('threads', lazy=True))

--- a/model/ThreadPosts.py
+++ b/model/ThreadPosts.py
@@ -15,6 +15,12 @@ class ThreadPosts:
         session.commit()
         return jsonify(self.retrieve(thread_id))
 
+    def delete(self, thread_id):
+        thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
+        board_id = thread.board
+        db.session.delete(thread)
+        db.session.commit()
+
     def retrieve(self, thread_id):
         session = db.session
         thread = session.query(Thread).filter(Thread.id == thread_id).one()

--- a/templates/thread.html
+++ b/templates/thread.html
@@ -164,6 +164,15 @@
 
 
 						</script>
+						{% if get_slip() and get_slip().is_admin or get_slip().is_mod %}
+							<div class="col-auto">
+								{% set ns = namespace(delete_url=url_for("threads.delete_post", post_id=post["id"])) %}
+								{% if loop.index0 == 0 %}
+									{% set ns.delete_url = url_for("threads.delete", thread_id=thread_id) %}
+								{% endif %}
+								<small><a class="badge badge-danger" href="{{ ns.delete_url }}">Delete</a></small>
+							</div>
+						{% endif %}
 					</div>
 					{% if post["replies"] %}
 						<div class="row">


### PR DESCRIPTION
Fixes #15 - it should be noted that attachment deletion is not currently handled, but the amount of code that would need to be changed on the moderation side would be pretty small once deletion was implemented on the storage backend, hence merging it now.

The REST endpoints are unguarded, but that's better left to a PR specifically for #11, I think.