### PR TITLE
Add initial support for text spoilers

### DIFF
--- a/model/Post.py
+++ b/model/Post.py
@@ -4,6 +4,7 @@ from flask import url_for
 from markdown import markdown
 
 from model.PostReplyExtension import PostReplyExtension
+from model.Spoiler import SpoilerExtension
 from model.ThreadRootExtension import ThreadRootExtension
 from outputmixin import OutputMixin
 from shared import db
@@ -11,13 +12,15 @@ from shared import db
 def render_for_catalog(posts):
     for post in posts:
         post["body"] = markdown(post["body"],
-                                extensions=[PostReplyExtension()])
+                                extensions=[PostReplyExtension(),
+                                            SpoilerExtension()])
 
 
 def render_for_threads(posts):
     for post in posts:
         post["body"] = markdown(post["body"],
-                                extensions=[ThreadRootExtension(), PostReplyExtension()])
+                                extensions=[ThreadRootExtension(), PostReplyExtension(),
+                                            SpoilerExtension()])
 
 
 class Post(OutputMixin, db.Model):

--- a/model/Spoiler.py
+++ b/model/Spoiler.py
@@ -1,0 +1,21 @@
+import re
+from markdown import Extension
+from markdown.inlinepatterns import Pattern
+from markdown.util import etree
+
+class SpoilerPattern(Pattern):
+    _SPOILER_REGEXP = r"\|\|(.+)\|\|"
+    def __init__(self, markdown_instance=None):
+        super().__init__(self._SPOILER_REGEXP, markdown_instance)
+
+    def handleMatch(self, match):
+        spoiler = etree.Element("span")
+        spoiler.text = match.group(2)
+        spoiler.attrib["class"] = "spoiler"
+        return spoiler
+
+
+class SpoilerExtension(Extension):
+    def extendMarkdown(self, md, _):
+        spoiler = SpoilerPattern()
+        md.inlinePatterns.add("spoiler", spoiler, "_begin")

--- a/static/css/styling.css
+++ b/static/css/styling.css
@@ -1,0 +1,7 @@
+.spoiler {
+	color: var(--dark);
+	background-color: var(--dark);
+}
+.spoiler:hover {
+	color: var(--white);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <link rel="stylesheet" href="{{ static_resource("bootstrap/css/bootstrap.min.css") }}">
+	<link rel="stylesheet" href="{{ static_resource("css/styling.css") }}">
     <script src="{{ static_resource("jquery/jquery-3.3.1.min.js") }}"></script>
     <script src="{{ static_resource("popperjs/umd/popper.min.js") }}"></script>
     <script src="{{ static_resource("bootstrap/js/bootstrap.min.js") }}"></script>


### PR DESCRIPTION
Fixes #10. Syntax is pretty simplistic, but it gets the job done. As an aside, it should be easier to add custom CSS as a consequence of a little bit of custom CSS being needed to implement this feature.