### PR TITLE
Add MIME type and WebP support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /maniwani
 # backend dependencies
 RUN pip install pipenv
 # dependencies for Pillow
-RUN apk add build-base jpeg-dev zlib-dev
+RUN apk add build-base jpeg-dev zlib-dev libwebp-dev
 # dependencies for psycopg2
 RUN apk add libpq postgresql-dev gcc python3-dev musl-dev
 RUN apk add ffmpeg

--- a/blueprints/boards.py
+++ b/blueprints/boards.py
@@ -66,6 +66,7 @@ def admin_update(board_id):
     board.name = args["name"]
     board.rules = args["rules"]
     board.max_threads = args["max-threads"]
+    board.mimetypes = args["mimetypes"]
     db.session.add(board)
     db.session.commit()
     return redirect(url_for("boards.catalog", board_id=board_id))

--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, redirect, url_for, flash
 
 from model.NewPost import NewPost, InvalidMimeError
 from model.NewThread import NewThread
-from model.Post import Post, render_for_threads, 
+from model.Post import Post, render_for_threads
 from model.PostRemoval import PostRemoval
 from model.PostReplyPattern import url_for_post
 from model.Poster import Poster

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -30,7 +30,13 @@ def setup_boards(json_settings):
     for board_info in json_settings["boards"]:
         name = board_info["name"]
         threadlimit = board_info.get("threadlimit") or json_settings["default_threadlimit"]
-        board = Board(name=name, max_threads=threadlimit)
+        mimetypes = board_info.get("mimetypes")
+        if mimetypes is None:
+            mimetypes = json_settings["default_mimetypes"]
+            extra_mimetypes = board_info.get("extra_mimetypes")
+            if extra_mimetypes:
+                mimetypes = mimetypes + "|" + extra_mimetypes
+        board = Board(name=name, max_threads=threadlimit, mimetypes=mimetypes)
         db.session.add(board)
 
 

--- a/build-helpers/bootstrap-config.json
+++ b/build-helpers/bootstrap-config.json
@@ -1,5 +1,6 @@
 {
 	"default_threadlimit": 100,
+	"default_mimetypes": "image/jpg|image/png|image/gif|image/webp|video/webm",
 	"boards": [
 		{
 			"name": "anime"

--- a/model/Board.py
+++ b/model/Board.py
@@ -11,3 +11,4 @@ class Board(db.Model):
     rules = db.Column(db.String, nullable=True)
     threads = relationship("Thread", order_by=desc(Thread.last_updated))
     max_threads = db.Column(db.Integer, default=50)
+    mimetypes = db.Column(db.String, nullable=False)

--- a/model/Media.py
+++ b/model/Media.py
@@ -11,6 +11,7 @@ from shared import db, app
 class Media(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     ext = db.Column(db.String(4), nullable=False)
+    mimetype = db.Column(db.String(255), nullable=False)
 
     def delete_attachment(self):
         storage.delete_attachment(self.id, self.ext)
@@ -20,7 +21,7 @@ class StorageBase:
     _FFMPEG_FLAGS = "-i pipe:0 -f mjpeg -frames:v 1 -vf scale=w=500:h=500:force_original_aspect_ratio=decrease pipe:1"
     def save_attachment(self, attachment_file):
         file_ext = attachment_file.filename.rsplit('.', 1)[1].lower()
-        media = Media(ext=file_ext)
+        media = Media(ext=file_ext, mimetype=attachment_file.content_type)
         db.session.add(media)
         db.session.flush()
         media_id = media.id

--- a/templates/board-admin.html
+++ b/templates/board-admin.html
@@ -18,6 +18,10 @@ administrate board
 			<label for="max-threads">Max threads</label>
 			<input type="text" id="max-threads" name="max-threads" class="form-control" value="{{ board.max_threads }}">
 		</div>
+		<div class="form-group">
+			<label for="mimetypes">Allowed MIME types</label>
+			<input type="text" id="mimetypes" name="mimetypes" class="form-control" value="{{ board.mimetypes | safe }}">
+		</div>
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
 </div>

--- a/templates/post-base.html
+++ b/templates/post-base.html
@@ -31,14 +31,6 @@
     <div class="form-group">
         <label for="media">Media upload</label>
         <input type="file" id="media" name="media">
-        <small class="form-text text-muted">Max file size is 5MB. Allowed file upload types are:
-            <ul>
-                <li>webm</li>
-                <li>png</li>
-                <li>jpg</li>
-                <li>gif</li>
-            </ul>
-        </small>
     </div>
     <input type="hidden" name="{{ hidden_name }}" value="{{ hidden_value }}">
     {% if embed_submit %}


### PR DESCRIPTION
This PR adds the ability to filter out what is and is not an acceptable media attachment on a per-board basis via a setting in `bootstrap-config.json` as well as through the web administration interface. WebP support is now also available out-of-the-box in any Docker-based build of Maniwani and through non-Docker builds if Pillow was compiled for support for the format.

Thumbnailing support wasn't improved beyond what was already implemented, however (so Maniwani will choke on text file uploads even if `text/*` was labeled as a valid MIME type), and currently all WebP images are considered to be static; this means that mouseover animation support is not currently extended to WebP and there is no way for the user to tell whether a WebP image is animated or not except by opening it. 