### PR TITLE
Add basic text thumbnailing support

### DIFF
--- a/build-helpers/bootstrap-config.json
+++ b/build-helpers/bootstrap-config.json
@@ -6,7 +6,8 @@
 			"name": "anime"
 		},
 		{
-			"name": "tech"
+			"name": "tech",
+			"extra_mimetypes": "text/*"
 		},
 		{
 			"name": "meta",


### PR DESCRIPTION
This PR causes the thumbnailer to check MIME type and not extension when determining how to thumbnail an attachment, as well as add support for thumbnailing text files via Pillow.