### PR TITLE
Add HTTP Basic security to REST API

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -4,8 +4,9 @@ Maniwani REST API v1
 Basics
 ------
 
-As of the latest revision of Maniwani, no authentication of any kind is
-required to use the API. Simply point `curl` or your custom client at
+As of the latest revision of Maniwani, sensitive REST endpoints (those that allow adding/deleting
+site content) require HTTP Basic authentication, using slips as the credential; however,
+the majority of the endpoints can be freely accessed. Simply point `curl` or your custom client at
 the endpoint of your choice. If there's something on the website that you find you
 cannot accomplish with REST, submit an issue report (or better yet, a pull request) - one
 of the primary goals of Maniwani is 1:1 feature parity between the web and REST frontends.

--- a/model/NewPostResource.py
+++ b/model/NewPostResource.py
@@ -1,7 +1,9 @@
 from flask_restful import Resource
 
 from model.NewPost import NewPost
-
+from restauth import slip_required
 
 class NewPostResource(NewPost, Resource):
-    pass
+    @slip_required
+    def post(self, thread_id):
+        super().post(thread_id)

--- a/model/PostRemovalResource.py
+++ b/model/PostRemovalResource.py
@@ -1,6 +1,8 @@
 from flask_restful import Resource
 from model.PostRemoval import PostRemoval
-
+from restauth import mod_required
 
 class PostRemovalResource(PostRemoval, Resource):
-    pass
+    @mod_required
+    def delete(self, post_id):
+        super().delete(post_id)

--- a/restauth.py
+++ b/restauth.py
@@ -1,0 +1,54 @@
+from functools import wraps
+
+from flask import request
+from werkzeug.security import check_password_hash
+
+from model.Slip import Slip
+from shared import db
+
+
+def _slip_check():
+    if request.authorization is None:
+        return None
+    username = request.authorization.username
+    slip = db.session.query(Slip).filter(Slip.name == username).one_or_none()
+    if slip is None:
+        return None
+    password = request.authorization.password
+    if check_password_hash(slip.pass_hash, password) is False:
+        return None
+    return slip
+
+
+def slip_required(endpoint):
+    @wraps(endpoint)
+    def auth_decorator(*args, **kwargs):
+        slip = _slip_check()
+        if slip is None:
+            return {"error": "Authentication failed"}, 401
+        return endpoint(*args, **kwargs)
+    return auth_decorator
+
+
+def admin_required(endpoint):
+    @wraps(endpoint)
+    def auth_decorator(*args, **kwargs):
+        slip = _slip_check()
+        if slip is None:
+            return {"error": "Authentication failed"}, 401
+        if slip.is_admin is False:
+            return {"error": "Authentication failed"}, 401
+        return endpoint(*args, **kwargs)
+    return auth_decorator
+
+
+def mod_required(endpoint):
+    @wraps(endpoint)
+    def auth_decorator(*args, **kwargs):
+        slip = _slip_check()
+        if slip is None:
+            return {"error": "Authentication failed"}, 401
+        if slip.is_admin is False and slip.is_mod is False:
+            return {"error": "Authentication failed"}, 401
+        return endpoint(*args, **kwargs)
+    return auth_decorator


### PR DESCRIPTION
This PR adds HTTP Basic protection to the existing REST endpoints in Maniwani's API. The current major caveat is that it doesn't require HTTPS on those endpoints, but one could argue that's the responsibility of the reverse proxy.