### PR TITLE
Rework catalog using CSS grid

### DIFF
--- a/scss/catalog.scss
+++ b/scss/catalog.scss
@@ -1,0 +1,38 @@
+.thread {
+	@extend .border;
+	@extend .rounded;
+	width: 300px;
+	height: 300px;
+	position: relative;
+}
+.thread-body {
+	font-size: 0.8em;
+}
+.catalog-grid {
+	display: grid;
+	justify-content: center;
+	grid-gap: 30px;
+	grid-template-columns: repeat(auto-fill, 300px);
+}
+.catalog-media-container {
+	@extend .p-2;
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+.catalog-thumbnail {
+	width: auto;
+	height: 125px;
+}
+.view-thread-container {
+	position: absolute;
+	bottom: 0;
+}
+.thread-stats-container {
+	@extend .p-1;
+	position: absolute;
+	bottom: 0;
+	right: 0;
+}

--- a/scss/maniwani.scss
+++ b/scss/maniwani.scss
@@ -1,5 +1,5 @@
 @import "bootstrap";
+@import "catalog";
 @import "post";
 @import "styling";
 @import "captchouli";
-

--- a/scss/styling.scss
+++ b/scss/styling.scss
@@ -5,7 +5,17 @@
 .spoiler:hover {
 	color: var(--white);
 }
-
+.spoiler-label {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	font-size: 6em;
+}
+.thumbnail-spoiler {
+	opacity: 0.3;
+	filter: blur(12px);
+}
 blockquote {
 	color: var(--green);
 }

--- a/templates/catalog-view.html
+++ b/templates/catalog-view.html
@@ -1,53 +1,6 @@
 {% macro catalog_view(threads, display_board=False) %}
-	<style>
-	 @media (max-width: 575px) {
-		 .thread, .thread-sizer {
-			 width: 98%;
-			 margin: 0.2em;
-		 }
-	 }
-	 /* Shim for responsive cards */
-	 @media (min-width: 576px) {
-		 .thread, .thread-sizer {
-			 width: 50%;
-		 }
-	 }
-	 @media (min-width: 768px) {
-		 .thread, .thread-sizer {
-			 width: 49%;
-			 margin: 0.2em;
-		 }
-	 }
-	 @media (min-width: 992px) {
-		 .thread, .thread-sizer {
-			 width: 24%;
-			 margin: 0.2em;
-		 }
-	 }
-	 @media (min-width: 1200px) {
-		 .thread, .thread-sizer {
-			 width: 19.5%;
-			 margin: 0.2em;
-		 }
-		 .catalog-padding {
-			 padding: 0px;
-		 }
-	 }
-	 .spoiler-label {
-		 position: absolute;
-		 top: 50%;
-		 left: 50%;
-		 transform: translate(-50%, -50%);
-		 font-size: 6em;
-	 }
-	</style>
-	<script src="{{ static_resource("imagesloaded/imagesloaded.pkgd.min.js") }}"></script>
-	<script src="{{ static_resource("masonry/masonry.pkgd.min.js") }}"></script>
-	<div class="container-fluid catalog-padding">
-		<div id="grid" class="d-flex flex-wrap">
-			<script>
-			 document.write('<div class="thread-sizer" style="display: none;"></div>')
-			</script>
+	<div class="container-fluid">
+		<div class="catalog-grid">
 			{% for thread in threads %}	
 				{% set bg_style = "bg-light" %}
 				{% set ns = namespace(bg_style="bg-light", text_style="text-body") %}	
@@ -64,35 +17,34 @@
 					{% set ns.bg_style = "bg-success" %}
 					{% set ns.text_style = "text-light" %}
 				{% endif %}
-				<div class="thread border-top rounded">
-					<div class="border-left border-right" style="position: relative; overflow: hidden;">
+				<div class="thread {{ ns.bg_style }}">
+					<div class="catalog-media-container">
 						<a href="{{ url_for("threads.view", thread_id=thread["id"]) }}">
-							{% set style_ns = namespace(extra_style="") %}
+							{% set style_ns = namespace(extra_class="") %}
 							{% if thread["spoiler"] == True %}
 								<span id="spoiler-label-{{ thread["media"] }}" class="spoiler-label text-danger">!</span>
-								{% set style_ns.extra_style = "opacity: 0.3; filter: blur(12px);" %}
+								{% set style_ns.extra_class = "thumbnail-spoiler" %}
 							{% endif %}
-							<img style="{{ style_ns.extra_style }}" class="w-100 rounded-top" src="{{ url_for("upload.thumb",
-																								   media_id=thread["media"]) }}">
-					</a>
-				</div>
-				{% if thread["subject"] %}
-					<div class="{{ "p-2 border-left border-right " + ns.bg_style }}">
-						<h5 class="{{ ns.text_style }}">{{ thread["subject"] }}</h5>
+							<img class="catalog-thumbnail {{ style_ns.extra_class }}" src="{{ url_for("upload.thumb", media_id=thread["media"])}}" >
+							
+						</a>
 					</div>
-				{% else %}
-					<div class="{{ "p-2 border-left border-right " + ns.bg_style }}">
-						<h5 class="text-muted">No subject</h5>
+					<div class="p-1">
+						{% if thread["subject"] %}
+							<h6 class="text-center font-weight-bold {{ ns.text_style }}">{{ thread["subject"] }}</h5>
+						{% else %}
+							<h6 class="text-center text-muted">No subject</h5>
+						{% endif %}
 					</div>
-				{% endif %}
-				<div class="{{  "pb-2 pt-2 pl-4 pr-4 border-left border-right " + ns.bg_style }}">
-					<div class="{{ ns.text_style }}">
-						 {{ thread["body"]|safe|truncate() }}
+					<div class="pb-2 pl-4 pr-4">
+						<div class="thread-body {{ ns.text_style }}">
+							{{ thread["body"]|safe|truncate(150) }}
+						</div>
 					</div>
-				</div>
-				<div class="{{ "pt-1 border border-top-0 rounded-bottom " + ns.bg_style }}">
-					<a href="{{ url_for("threads.view", thread_id=thread["id"]) }}" class="btn btn-dark m-2">View thread</a>
-					<span class="{{ "mt-3 mr-2 float-right " + ns.text_style }}">
+					<div class="view-thread-container">
+						<a href="{{ url_for("threads.view", thread_id=thread["id"]) }}" class="btn btn-dark m-2">View thread</a>
+					</div>
+					<span class="thread-stats-container {{ ns.text_style }}">
 						{% if display_board %}
 							<small>/{{ thread["board"] }}/</small>
 						{% endif %}
@@ -100,22 +52,7 @@
 						<i class="fas fa-image"></i> {{ thread["num_media"] }}
 					</span>
 				</div>
-			</div>
-{% endfor %}
-</div>
-</div>
-<script>
-	 var grid = $("#grid")
-	 grid.imagesLoaded( function() {
-		 grid.masonry({
-			 columnWidth: '.thread-sizer',
-			 itemSelector: '.thread',
-			 percentPosition: true,
-			 horizontalOrder: true
-		 })
-	 })
-
-
-
-</script>
+			{% endfor %}
+		</div>
+	</div>
 {% endmacro %}

--- a/templates/thread.html
+++ b/templates/thread.html
@@ -15,13 +15,6 @@
 		 position: relative;
 		 text-align: center;
 	 }
-	 .spoiler-label {
-		 position: absolute;
-		 top: 50%;
-		 left: 50%;
-		 transform: translate(-50%, -50%);
-		 font-size: 6em;
-	 }
 	</style>
 {% endblock %}
 {% block navbar %}


### PR DESCRIPTION
Fixes #54 (though with grid instead of flexbox) by removing the dependency on masonry for rendering the catalog and firehose, in addition to performing a partial refactor on the catalog macro in `templates/catalog-view.html`. This PR probably warrants some updated screenshots in the README.