### PR TITLE
Implement IP version agnostic ip_to_int

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -1,5 +1,6 @@
 import os
 import random
+import ipaddress
 from customjsonencoder import CustomJSONEncoder
 from flask import Flask
 from flask_migrate import Migrate

--- a/shared.py
+++ b/shared.py
@@ -36,11 +36,9 @@ def gen_poster_id():
 
 
 def ip_to_int(ip_str):
-    # TODO: IPv6 support
-    segments = [int(s) for s in ip_str.split(".")]
-    segments.reverse()
-    ip_num = 0
-    for segment in segments:
-        ip_num = ip_num | segment
-        ip_num = ip_num << 8
-    return ip_num
+    # The old version of ip_to_int had a logical bug where it would always shift the
+    # final result to the left by 8. This is preserved with the `<< 8`.
+    return int.from_bytes(
+        ipaddress.ip_address(ip_str).packed,
+        byteorder="little"
+    ) << 8


### PR DESCRIPTION
This updates ip_to_int to use the standard ipaddress Python library. This function will produce the same output as the old ip_to_int when given IPv4 addresses.