### PR TITLE
Fix devmode boot issues

### DIFF
--- a/build-helpers/docker-entrypoint.sh
+++ b/build-helpers/docker-entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-# dev mode - file storage backend, sqlite, no wsgi/nginx, etc.
+# dev mode - file storage backend, sqlite, no nginx, etc.
 if [ $1 = "devmode" ]; then
 	# start up internal pubsub server
-	python storestub.py
-	uwsgi --ini ./deploy-configs/uwsgi.ini
-# attempting to bootstrap a production environment?
+	python storestub.py &
+	uwsgi --ini ./deploy-configs/uwsgi-devmode.ini
+# attempting to bootstrap?
 elif [ $1 = "bootstrap" ]; then
 	python3 bootstrap.py
 # version upgrade?

--- a/deploy-configs/uwsgi-devmode.ini
+++ b/deploy-configs/uwsgi-devmode.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+module = wsgi
+master = true
+processes = 4
+gevent = 10
+die-on-term = true
+plugin = python3,gevent,http
+
+http = 0.0.0.0:5000
+wsgi-file = app.py
+callable = app

--- a/storestub.py
+++ b/storestub.py
@@ -8,6 +8,7 @@ import struct
 KEYSTORE_PORT = 5577
 KEYSTORE_GET = "get"
 KEYSTORE_SET = "set"
+KEYSTORE_DELETE = "delete"
 PUBSUB_PORT = 5578
 PUBSUB_SUBSCRIBE = "subscribe"
 PUBSUB_UNSUBSCRIBE = "unsubsribe"


### PR DESCRIPTION
This PR fixes the `dev` target of the Docker image, allowing Maniwani to work/run as a single-containner application again by adding a `dev`-specific uWSGI config, among several other minor fixes.