### PR TITLE
Add functionality to move threads to a different board

### DIFF
--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for, flash
+from flask import Blueprint, render_template, redirect, url_for, flash, request
 
 import captchouli
 import cooldown
@@ -76,6 +76,28 @@ def delete(thread_id):
     flash("Thread deleted!")
     return redirect(url_for("boards.catalog", board_id=board_id))
 
+
+@threads_blueprint.route("/<int:thread_id>/move")
+def move(thread_id):
+    if not get_slip() or not (get_slip().is_admin or get_slip().is_mod):
+        flash("Only moderators and admins can move threads!")
+        return redirect(url_for("threads.view", thread_id=thread_id))
+    return render_template("thread-move.html", thread_id=thread_id)
+
+
+@threads_blueprint.route("/<int:thread_id>/move", methods=["POST"])
+def move_submit(thread_id):
+    if not get_slip() or not (get_slip().is_admin or get_slip().is_mod):
+        flash("Only moderators and admins can move threads!")
+        return redirect(url_for("threads.view", thread_id=thread_id))
+    thread = Thread.query.get(thread_id)
+    board = Board.query.filter(Board.name == request.form["board"]).one()
+    thread.board = board.id
+    db.session.add(thread)
+    db.session.commit()
+    flash("Thread moved!")
+    return redirect(url_for("threads.view", thread_id=thread_id))
+    
 
 @threads_blueprint.route("/<int:thread_id>/new")
 def new_post(thread_id):

--- a/scss/base/styling.scss
+++ b/scss/base/styling.scss
@@ -22,3 +22,10 @@
 blockquote {
 	color: var(--green);
 }
+.mod-item {
+	display: block;
+	@extend .w-100;
+	@extend .my-1;
+	@extend .badge;
+	@extend .badge-primary;
+}

--- a/templates/post-view.html
+++ b/templates/post-view.html
@@ -100,7 +100,13 @@
 						{% if is_op %}
 							{% set ns.delete_url = url_for("threads.delete", thread_id=thread_id) %}
 						{% endif %}
-						<small><a class="badge badge-danger" href="{{ ns.delete_url }}">Delete</a></small>
+						<details class="badge badge-danger">
+							<summary>Moderation</summary>
+							{% if is_op %}
+								<a class="mod-item" href="{{ url_for("threads.move", thread_id=thread_id) }}">Move</a>
+							{% endif %}
+							<a class="mod-item" href="{{ ns.delete_url }}">Delete</a>
+						</details>
 					</div>
 				{% endif %}
 			</div>

--- a/templates/thread-move.html
+++ b/templates/thread-move.html
@@ -1,0 +1,14 @@
+{%- extends "base.html" %}
+{% block title %}
+	move thread
+{% endblock %}
+{% block content %}
+	<div class="container">
+		<form method="post" enctype="multipart/form-data" action="{{ url_for("threads.move_submit", thread_id=thread_id) }}"
+			<div class="form-group">
+				<label for="board">Move thread to board:</label>
+				<input type="text" id="board" name="board" class="form-control">
+			</div>
+		</form>
+	</div>
+{% endblock %}


### PR DESCRIPTION
Closes #53. Doesn't extend the REST API, but we can add that in later.