### PR TITLE
split post/thread logic from models + make them datasource agnostic

### DIFF
--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -5,7 +5,7 @@ import captchouli
 import cooldown
 from model.Media import upload_size
 from model.Board import Board
-from model.NewPost import NewPost, InvalidMimeError, CaptchaError
+from model.NewPost import NewPost
 from model.NewThread import NewThread
 from model.Post import Post, render_for_threads
 from model.PostRemoval import PostRemoval
@@ -15,6 +15,7 @@ from model.Slip import get_slip
 from model.SubmissionError import SubmissionError
 from model.Thread import Thread
 from model.ThreadPosts import ThreadPosts
+from post import InvalidMimeError, CaptchaError
 from shared import db, app
 
 
@@ -38,7 +39,7 @@ def new(board_id):
 @threads_blueprint.route("/new", methods=["POST"])
 def submit():
     try:
-        thread = NewThread().post_impl()
+        thread = NewThread().post()
         return redirect(url_for("threads.view", thread_id=thread.id))
     except SubmissionError as e:
         flash(str(e.args[0]))

--- a/model/NewPost.py
+++ b/model/NewPost.py
@@ -1,137 +1,49 @@
-import json
-import os
-import re
-import string
+from typing import Union
 
-from PIL import Image
-from flask import current_app, request
+from flask import request
 from flask_restful import reqparse, inputs
-import requests
 
-import cache
-import captchouli
-import cooldown
-import keystore
-from model.Board import Board
-from model.Media import Media, storage
-from model.Poster import Poster
-from model.Post import Post
-from model.Reply import Reply, REPLY_REGEXP
 from model.Thread import Thread
-from model.ThreadPosts import thread_posts_cache_key
-from model.Slip import get_slip
-from shared import app, db, gen_poster_id
+from model.Post import Post
+
+from cooldown import on_captcha_cooldown, refresh_captcha_cooldown
+from post import create_post
+from shared import app, db
+
+def get_request_data() -> reqparse.Namespace:
+    "Returns data about a new post request."
+
+    parser = reqparse.RequestParser()
+    parser.add_argument("subject", type=str)
+    parser.add_argument("body", type=str, required=True)
+    parser.add_argument("useslip", type=inputs.boolean)
+    parser.add_argument("spoiler", type=inputs.boolean)
+
+    if not on_captcha_cooldown():
+        captcha_method = app.config.get("CAPTCHA_METHOD")
+        if captcha_method == "RECAPTCHA":
+            parser.add_argument("recaptcha-token", type=str, required=True)
+        elif captcha_method == "CAPTCHOULI":
+            parser.add_argument("captchouli-id", type=str, required=True)
+            for i in range(9):
+                # For each image square
+                parser.add_argument(f"captchouli-{i}", type=str, default=False)
+
+    return parser.parse_args()
+
+
+def get_thread(thread_id: int) -> Thread:
+    "Returns a thread by its ID."
+    return (
+        db.session.query(Thread)
+        .filter_by(id=thread_id)
+        .one()
+    )
 
 
 class NewPost:
-    def post(self, thread_id):
-        parser = reqparse.RequestParser()
-        parser.add_argument("subject", type=str)
-        parser.add_argument("body", type=str, required=True)
-        parser.add_argument("useslip", type=inputs.boolean)
-        parser.add_argument("spoiler", type=inputs.boolean)
-        # check captcha cooldown
-        on_cooldown = cooldown.on_captcha_cooldown()
-        # only check of captcha if the client is not on cooldown
-        if on_cooldown is False:
-            if app.config.get("CAPTCHA_METHOD") == "RECAPTCHA":
-                parser.add_argument("recaptcha-token", type=str, required=True)
-            elif app.config.get("CAPTCHA_METHOD") == "CAPTCHOULI":
-                parser.add_argument("captchouli-id", type=str, required=True)
-                for img_num in range(0, 9):
-                    # don't bother validating too closely since captchouli takes care of
-                    # that for us
-                    parser.add_argument("captchouli-%d" % img_num, type=str, default=False)
-        args = parser.parse_args()
-        ip = None
-        # reverse proxy support
-        if 'X-Forwarded-For' in request.headers:
-            ip = request.headers.getlist("X-Forwarded-For")[0].rpartition(' ')[-1]
-        else:
-            ip = request.environ["REMOTE_ADDR"]
-        # check captcha if necessary
-        board_id = db.session.query(Thread).filter_by(id=thread_id).one().board
-        if on_cooldown is False:
-            if app.config.get("CAPTCHA_METHOD") == "RECAPTCHA":
-                google_response = requests.post("https://www.google.com/recaptcha/api/siteverify",
-                                                data={"secret": app.config["RECAPTCHA_SECRET_KEY"],
-                                                      "response": args["recaptcha-token"]}).json()
-                if google_response["success"] is False:
-                    raise CaptchaError("Problem getting reCAPTCHA", board_id)
-                if google_response["score"] < app.config["RECAPTCHA_THRESHOLD"]:
-                    raise CaptchaError("reCAPTCHA threshold too low", board_id)
-            elif app.config.get("CAPTCHA_METHOD") == "CAPTCHOULI":
-                captchouli_form = {"captchouli-id": args["captchouli-id"]}
-                for img_num in range(0, 9):
-                    key = "captchouli-%d" % img_num
-                    captchouli_form[key] = args[key]
-                if not captchouli.valid_solution(captchouli_form):
-                    raise CaptchaError("Incorrect CAPTCHA response", board_id)
-        cooldown.refresh_captcha_cooldown()
-        poster = db.session.query(Poster).filter_by(thread=thread_id, ip_address=ip).first()
-        body = args["body"]
-        should_bump = False
-        if poster is None:
-            poster_hex = gen_poster_id()
-            poster = Poster(hex_string=poster_hex, ip_address=ip, thread=thread_id)
-            db.session.add(poster)
-            db.session.flush()
-            # bump thread if the poster hasn't posted in this thread before
-            should_bump = True
-        else:
-            # bump thread if this poster isn't the same as the one who posted last in the thread
-            last_post = db.session.query(Post).filter_by(thread=thread_id).order_by(Post.id.desc()).first()
-            if last_post.poster != poster.id:
-                should_bump = True
-        if args.get("useslip") is True:
-            slip = get_slip()
-            if slip and (slip.is_admin or slip.is_mod):
-                poster.slip = slip.id
-                db.session.add(poster)
-        media_id = None
-        if "media" in request.files and request.files["media"].filename:
-            uploaded_file = request.files["media"]
-            mimetype = uploaded_file.content_type
-            board = db.session.query(Board).filter_by(id=board_id).one()
-            expected_mimetypes = board.mimetypes
-            if re.match(expected_mimetypes, mimetype) is None:
-                db.session.rollback()
-                raise InvalidMimeError(mimetype, board_id)
-            media = storage.save_attachment(uploaded_file)
-            media_id = media.id
-        post = Post(body=body, subject=args["subject"], thread=thread_id, poster=poster.id, media=media_id,
-                    spoiler=args["spoiler"])
-        db.session.add(post)
-        db.session.flush()
-        replying = re.finditer(REPLY_REGEXP, body)
-        replies = set()
-        if replying:
-            for match in replying:
-                raw_reply_id = match.group(2)
-                reply_id = int(raw_reply_id)
-                replies.add(reply_id)
-            for reply_id in replies:
-                reply = Reply(reply_from=post.id, reply_to=reply_id)
-                db.session.add(reply)
-        if should_bump:
-            thread = db.session.query(Thread).filter_by(id=thread_id).one()
-            thread.last_updated = post.datetime
-            db.session.add(thread)
-        db.session.flush()
-        db.session.commit()
-        cache_connection = cache.Cache()
-        cache_connection.invalidate(thread_posts_cache_key(thread_id))
-        pubsub_client = keystore.Pubsub()
-        pubsub_client.publish("new-post", json.dumps({"thread": thread_id, "post": post.id}))
-        for reply_id in replies:
-            pubsub_client.publish("new-reply", json.dumps({"post": post.id, "thread": post.thread, "reply_to": reply_id}))
-            replied_post = db.session.query(Post).get(reply_id)
-            cache_connection.invalidate(thread_posts_cache_key(replied_post.thread))
-
-
-class InvalidMimeError(Exception):
-    pass
-
-
-class CaptchaError(Exception):
-    pass
+    def post(self, thread: Union[Thread, int]) -> Post:
+        if isinstance(thread, int):
+            thread = get_thread(thread)
+        args = dict(get_request_data())
+        return create_post(thread, args)

--- a/model/NewThread.py
+++ b/model/NewThread.py
@@ -1,50 +1,22 @@
-import json
-
-from flask import request
 from flask_restful import reqparse
-from sqlalchemy import desc
 
-import keystore
-from model.Board import Board
-from model.NewPost import NewPost
-from model.SubmissionError import SubmissionError
-from model.Tag import Tag
-from model.Thread import Thread
-from shared import db
+from thread import create_thread
+
+
+def get_request_data() -> reqparse.Namespace:
+    "Returns data about a new thread request."
+
+    parser = reqparse.RequestParser()
+    parser.add_argument("subject", type=str)
+    parser.add_argument("body", type=str, required=True)
+    parser.add_argument("board", type=int, required=True)
+    parser.add_argument("tags", type=str)
+
+    return parser.parse_args()
 
 
 class NewThread:
     def post(self):
-        self.post_impl()
+        args = dict(get_request_data())
 
-    def post_impl(self):
-        parser = reqparse.RequestParser()
-        parser.add_argument("subject", type=str)
-        parser.add_argument("body", type=str, required=True)
-        parser.add_argument("board", type=int, required=True)
-        parser.add_argument("tags", type=str)
-        args = parser.parse_args()
-        if "media" not in request.files or not request.files["media"].filename:
-            raise SubmissionError("A file is required to post a thread!", args["board"])
-        tags = []
-        if args["tags"]:
-            tag_list = args["tags"].replace(" ", "").split(",")
-            for tag_name in tag_list:
-                tag = db.session.query(Tag).filter(Tag.name == tag_name).one_or_none()
-                if tag is None:
-                    tag = Tag(name=tag_name)
-                    db.session.add(tag)
-                tags.append(tag)
-        db.session.flush()
-        num_threads = db.session.query(Thread).filter(Thread.board == args["board"]).count()
-        board = db.session.query(Board).filter(Board.id == args["board"]).one()
-        if num_threads >= board.max_threads:
-            dead_thread = db.session.query(Thread).filter(Thread.board == args["board"]).order_by(Thread.last_updated.asc()).first()
-            db.session.delete(dead_thread)
-        thread = Thread(board=args["board"], views=0, tags=tags)
-        db.session.add(thread)
-        db.session.flush()
-        NewPost().post(thread_id=thread.id)
-        pubsub_client = keystore.Pubsub()
-        pubsub_client.publish("new-thread", json.dumps({"thread": thread.id, "board": thread.board}))
-        return thread
+        return create_thread(args)

--- a/post.py
+++ b/post.py
@@ -1,0 +1,234 @@
+"""
+This module is responsible for creating posts out of post data.
+"""
+
+import json
+import re
+from typing import Tuple, Set, List
+
+from flask import request
+from flask_restful import reqparse, inputs
+import requests
+
+from cache import Cache
+import captchouli
+from cooldown import on_captcha_cooldown, refresh_captcha_cooldown
+import keystore
+from model.Board import Board
+from model.Media import storage
+from model.Poster import Poster
+from model.Post import Post
+from model.Reply import Reply, REPLY_REGEXP
+from model.Thread import Thread
+from model.ThreadPosts import thread_posts_cache_key
+from model.Slip import get_slip
+from shared import app, db, gen_poster_id
+
+
+class InvalidMimeError(Exception):
+    "Error to be thrown when the mimetype is invalid for an attachment."
+
+
+class CaptchaError(Exception):
+    "Error to be thrown when captcha is invalid."
+
+
+GOOGLE_RECAPTCHA_PATH = "https://www.google.com/recaptcha/api/siteverify"
+
+
+def get_ip_address() -> str:
+    "Returns the current IP address of the user."
+
+    if "X-Forwarded-For" in request.headers:
+        return request.headers.getlist("X-Forwarded-For")[0].split()[-1]
+    return request.environ["REMOTE_ADDR"]
+
+
+def validate_captcha(board_id: int, args: dict) -> None:
+    "Validates the authenticity of the current user with a captcha."
+
+    if on_captcha_cooldown():
+        return
+
+    captcha_method = app.config.get("CAPTCHA_METHOD")
+    if captcha_method == "RECAPTCHA":
+        google_response = requests.post(
+            GOOGLE_RECAPTCHA_PATH,
+            data={
+                "secret": app.config.get("RECAPTCHA_SECRET_KEY"),
+                "response": args["recaptcha-token"]
+            }
+        ).json()
+
+        if not google_response["success"]:
+            raise CaptchaError("reCAPTCHA response failed", board_id)
+
+        if google_response["score"] < app.config["RECAPTCHA_THRESHOLD"]:
+            raise CaptchaError("reCAPTCHA score below threshold", board_id)
+    elif captcha_method == "CAPTCHOULI":
+        captchouli_args = {
+            k: v for k, v in args
+            if k.startswith("captchouli")
+        }
+        if not captchouli.valid_solution(captchouli_args):
+            raise CaptchaError("Incorrect CAPTCHA solution", board_id)
+    else:
+        # TODO is this supposed to be nothing at all? raise exception?
+        pass
+
+    refresh_captcha_cooldown()
+
+
+def get_or_update_poster(thread_id: int, ip: str) -> Tuple[Poster, bool]:
+    """
+    Returns the current poster (creating one if it doesn't exist) and whether
+    this poster is the last poster in the current thread.
+    """
+
+    poster = (
+        db.session.query(Poster)
+        .filter_by(thread=thread_id, ip_address=ip)
+        .first()
+    )
+
+    if poster is None:
+        poster_hex = gen_poster_id()
+        poster = Poster(hex_string=poster_hex, ip_address=ip, thread=thread_id)
+        db.session.add(poster)
+        db.session.flush()
+
+        return (poster, False)
+
+    last_post = (
+        db.session.query(Post)
+        .filter_by(thread=thread_id)
+        .order_by(Post.id.desc())
+        .first()
+    )
+
+    if last_post is None or last_post.poster != poster.id:
+        return (poster, False)
+    return (poster, True)
+
+
+def update_poster_slip(poster: Poster, args: dict) -> None:
+    "Updates the current poster with a slip if necessary."
+
+    if args.get("useslip") is True:
+        slip = get_slip()
+        if slip and (slip.is_admin or slip.is_mod):
+            poster.slip = slip.id
+            db.session.add(poster)
+
+
+def get_media_id(board_id: int) -> int:
+    "Get the media ID for this request, or None if no media was uploaded."
+
+    f = request.files.get("media")
+    if not f or not f.filename:
+        return None
+
+    # Check the mimetype
+    mimetype = f.content_type
+    allowed_mimes = (
+        db.session.query(Board)
+        .filter_by(id=board_id)
+        .one()
+    ).mimetypes
+
+    if re.match(allowed_mimes, mimetype) is None:
+        db.session.rollback()
+        raise InvalidMimeError(mimetype, board_id)
+
+    return storage.save_attachment(f).id
+
+
+def get_replies(post_id: int, body: str) -> Set[Reply]:
+    "Returns a list of Reply objects for this post (unique IDs)."
+
+    ids = set()
+    iterator = re.finditer(REPLY_REGEXP, body)
+
+    if not iterator:
+        return []
+
+    for match in iterator:
+        # match.group(2) == the post ID
+        ids.add(int(match.group(2)))
+    return list(map(lambda id: Reply(reply_from=post_id, reply_to=id), ids))
+
+def publish_thread(thread: Thread, post: Post, replies: List[Reply]) -> None:
+    """
+    Publish a new post to the pub-sub system, also invalidating the cache in
+    the process.
+    """
+
+    client = keystore.Pubsub()
+    client.publish("new-post", json.dumps({
+        "thread": thread.id,
+        "post": post.id,
+    }))
+    for reply in replies:
+        client.publish("new-reply", json.dumps({
+            "thread": post.thread,
+            "post": post.id,
+            "reply_to": reply.reply_to,
+        }))
+
+
+def invalidate_posts(thread: Thread, replies: List[Reply]):
+    "Invalidates the respective cache pages after a post has been created."
+
+    cache = Cache()
+    cache.invalidate(thread_posts_cache_key(thread.id))
+
+    reply_ids = list(map(lambda r: r.reply_to, replies))
+    thread_ids = (
+        db.session.query(Post.thread)
+        .filter(Post.id.in_(reply_ids))
+        .all()
+    )
+    for thread_id in thread_ids:
+        cache.invalidate(thread_posts_cache_key(thread_id))
+
+
+def create_post(thread: Thread, args: dict) -> Post:
+    "Creates a new post from the given data."
+
+    board_id = thread.board
+    validate_captcha(board_id, args)
+
+    ip = get_ip_address()
+    poster, flooding = get_or_update_poster(thread.id, ip)
+
+    update_poster_slip(poster, args)
+
+    media_id = get_media_id(board_id)
+
+    post = Post(
+        body=args["body"],
+        subject=args["subject"],
+        thread=thread.id,
+        poster=poster.id,
+        media=media_id,
+        spoiler=args["spoiler"],
+    )
+    db.session.add(post)
+    db.session.flush()
+
+    replies = get_replies(post.id, post.body)
+    for reply in replies:
+        db.session.add(reply)
+
+    if not flooding:
+        # bump the thread if the last poster isn't the same
+        thread.last_updated = post.datetime
+        db.session.add(thread)
+
+    db.session.flush()
+    db.session.commit()
+
+    publish_thread(thread, post, replies)
+    invalidate_posts(thread, replies)
+
+    return post

--- a/thread.py
+++ b/thread.py
@@ -1,0 +1,98 @@
+import json
+from typing import List
+
+from flask import request
+from flask_restful import reqparse
+from sqlalchemy import desc
+
+import keystore
+from model.Board import Board
+from model.NewPost import NewPost
+from model.SubmissionError import SubmissionError
+from model.Tag import Tag
+from model.Thread import Thread
+from shared import db
+
+
+def get_tags(args: dict) -> List[Tag]:
+    "Returns a list of Tag objects from the given tag list."
+    if not args["tags"]:
+        return
+
+    tags = list(map(lambda s: s.strip(), args["tags"].split(",")))
+    ret = []
+
+    # add all the tags that already exist in the database
+    for row in db.session.query(Tag, Tag.name).filter(Tag.name.in_(tags)):
+        tags.remove(row.name)
+        ret.append(row.Tag)
+
+    # create the remaining tabs and add them to the transaction
+    # (the above loop removes all tags that already exist in the database
+    # from the list, # therefore simply looping over the tags list should
+    # suffice)
+    for tag in tags:
+        ret.append(Tag(name=tag))
+
+    return ret
+
+
+def slide_last_thread(board_id: int):
+    """
+    If the maximum amount of threads have been reached on the board, slides
+    off the last thread on the board.
+    """
+
+    num_threads = (
+        db.session.query(Thread)
+        .filter(Thread.board == board_id)
+        .count()
+    )
+    board_max_threads = (
+        db.session.query(Board.max_threads)
+        .filter(Board.id == board_id)
+        .one()
+    ).max_threads
+
+    if num_threads >= board_max_threads:
+        dead_thread = (
+            db.session.query(Thread)
+            .filter(Thread.board == board_id)
+            .order_by(Thread.last_updated.asc())
+            .first()
+        )
+        db.session.delete(dead_thread)
+
+
+def publish_new_thread(thread: Thread):
+    "Publishes the new thread to the pub-sub system."
+
+    client = keystore.Pubsub()
+    client.publish("new-thread", json.dumps({
+        "thread": thread.id,
+        "board": thread.board,
+    }))
+
+
+def create_thread(args: dict) -> Thread:
+    "Creates a new thread out of the given arguments."
+
+    if "media" not in request.files or not request.files["media"].filename:
+        raise SubmissionError(
+            "A file is required to post a thread!", args["board"])
+
+    tags = get_tags(args)
+    for tag in tags:
+        db.session.add(tag)
+    db.session.flush()
+
+    slide_last_thread(args["board"])
+
+    thread = Thread(board=args["board"], views=0, tags=tags)
+    db.session.add(thread)
+    db.session.flush()
+    NewPost().post(thread)
+
+    publish_new_thread(thread)
+
+    return thread


### PR DESCRIPTION
Currently maniwani's post/thread logic is embedded inside the model
files. This commit splits them into their own respective files, and
also increases efficiency on some queries (no queries inside loops and
using IN instead, not re-fetching the thread when a new thread is created).