### PR TITLE
Add full-page cache support for threads

### DIFF
--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request, copy_current_request_context
 
+import cache
 import captchouli
 import cooldown
 from model.Media import upload_size
@@ -10,7 +11,7 @@ from model.Post import Post, render_for_threads
 from model.PostRemoval import PostRemoval
 from model.PostReplyPattern import url_for_post
 from model.Poster import Poster
-from model.Slip import get_slip
+from model.Slip import get_slip, get_slip_bitmask
 from model.SubmissionError import SubmissionError
 from model.Thread import Thread
 from model.ThreadPosts import ThreadPosts
@@ -53,18 +54,36 @@ def submit():
 
 @threads_blueprint.route("/<int:thread_id>")
 def view(thread_id):
-    posts = ThreadPosts().retrieve(thread_id)
-    render_for_threads(posts)
     thread = db.session.query(Thread).filter(Thread.id == thread_id).one()
     thread.views += 1
     db.session.add(thread)
     db.session.commit()
+    cache_connection = cache.Cache()
+    view_key = "thread-%d-views" % thread_id
+    cached_views = cache_connection.get(view_key)
+    fetch_from_cache = True
+    if cached_views is None:
+        fetch_from_cache = False
+    else:
+        cached_views = int(cached_views)
+    if fetch_from_cache and (thread.views / cached_views) >= app.config.get("CACHE_VIEW_RATIO", 0):
+        fetch_from_cache = False
+    response_cache_key = "thread-%d-%d-render" % (thread_id, get_slip_bitmask())
+    if fetch_from_cache:
+        cache_response_body = cache_connection.get(response_cache_key)
+        if cache_response_body is not None:
+            return cache_response_body
+        else:
+    posts = ThreadPosts().retrieve(thread_id)
+    render_for_threads(posts)
     board = db.session.query(Board).get(thread.board)
     num_posters = db.session.query(Poster).filter(Poster.thread == thread_id).count()
     num_media = thread.num_media()
     reply_urls = _get_reply_urls(posts)
     template = render_template("thread.html", thread_id=thread_id, board=board, posts=posts, num_views=thread.views,
                                num_media=num_media, num_posters=num_posters, reply_urls=reply_urls)
+    cache_connection.set(view_key, str(thread.views))
+    cache_connection.set(response_cache_key, template)
     return template
 
 

--- a/blueprints/threads.py
+++ b/blueprints/threads.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, request, copy_current_request_context
+from flask import Blueprint, render_template, redirect, url_for, flash, request, copy_current_request_context, session
 
 import cache
 import captchouli
@@ -68,12 +68,12 @@ def view(thread_id):
         cached_views = int(cached_views)
     if fetch_from_cache and (thread.views / cached_views) >= app.config.get("CACHE_VIEW_RATIO", 0):
         fetch_from_cache = False
-    response_cache_key = "thread-%d-%d-render" % (thread_id, get_slip_bitmask())
+    current_theme = session.get("theme") or app.config.get("DEFAULT_THEME") or "stock"
+    response_cache_key = "thread-%d-%d-%s-render" % (thread_id, get_slip_bitmask(), current_theme)
     if fetch_from_cache:
         cache_response_body = cache_connection.get(response_cache_key)
         if cache_response_body is not None:
             return cache_response_body
-        else:
     posts = ThreadPosts().retrieve(thread_id)
     render_for_threads(posts)
     board = db.session.query(Board).get(thread.board)

--- a/cache.py
+++ b/cache.py
@@ -11,5 +11,6 @@ class Cache:
     def set(self, key, value):
         self._keystore.set(key, value)
     def invalidate(self, key):
-        self._keystore.delete(key)
+        if self._keystore.exists(key):
+            self._keystore.delete(key)
 

--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -105,6 +105,11 @@ but a brief description of each follows:
   supply these options unless `CAPTCHA_METHOD` has been set to `"RECAPTCHA"`, obviously.
 * `CAPTCHOULI_URL` - an URL specifying where the captchouli server has been set up. Only required if
   `CAPTCHA_METHOD` has been set to `"CAPTCHOULI"`.
+* `CACHE_VIEW_RATIO` - an optional integer that Maniwani will check when caching threads. If set, Maniwani will cache
+  a pre-rendered copy of a thread until the real view count divided by the view count in the cached render is greater
+  than this number. If not set, Maniwani will not attempt to fetch any fully-rendered threads from the cache. Set this
+  if site performance proves to be an issue; a good initial value is `1.15`.
+  
 
 `bootstrap-config.json` is the file used upon bootstrapping Maniwani for the first time to set up any boards,
 configure any initial slips (usually admin/moderator roles, but they don't have to be) and set up any special

--- a/model/Slip.py
+++ b/model/Slip.py
@@ -26,6 +26,18 @@ def get_slip():
     return None
 
 
+def get_slip_bitmask():
+    slip = get_slip()
+    if slip is None:
+        return 0
+    bitmask = 1
+    if slip.is_admin:
+        bitmask |= 2
+    if slip.is_mod:
+        bitmask |= 4
+    return bitmask
+
+
 def slip_from_id(slip_id):
     return db.session.query(Slip).filter(Slip.id == slip_id).one()
 

--- a/post.py
+++ b/post.py
@@ -182,9 +182,11 @@ def invalidate_posts(thread: Thread, replies: List[Reply]):
     cache = Cache()
     cache.invalidate(thread_posts_cache_key(thread.id))
     slip_bitmasks = 0, 1, 3, 7
+    theme_list = app.config.get("THEME_LIST") or ("stock", "harajuku", "wildride")
     for bitmask in slip_bitmasks:
-        render_cache_key = "thread-%d-%d-render" % (thread.id, bitmask)
-        cache.invalidate(render_cache_key)
+        for theme in theme_list:
+            render_cache_key = "thread-%d-%d-%s-render" % (thread.id, bitmask, theme)
+            cache.invalidate(render_cache_key)
 
     reply_ids = list(map(lambda r: r.reply_to, replies))
     thread_ids = (

--- a/post.py
+++ b/post.py
@@ -181,6 +181,10 @@ def invalidate_posts(thread: Thread, replies: List[Reply]):
 
     cache = Cache()
     cache.invalidate(thread_posts_cache_key(thread.id))
+    slip_bitmasks = 0, 1, 3, 7
+    for bitmask in slip_bitmasks:
+        render_cache_key = "thread-%d-%d-render" % (thread.id, bitmask)
+        cache.invalidate(render_cache_key)
 
     reply_ids = list(map(lambda r: r.reply_to, replies))
     thread_ids = (


### PR DESCRIPTION
This PR adds support for Maniwani to return a cached render of a thread until the difference between the real view count and the view count on the cached render surpasses a ratio specified in the optional configuration variable `CACHE_VIEW_RATIO`.