### PR TITLE
Add ETag/cache support to catalogs and the firehose

### DIFF
--- a/blueprints/live.py
+++ b/blueprints/live.py
@@ -77,7 +77,7 @@ def live_firehose():
             # client closed connection
             keystore_client.delete(client_id)
     response = Response(client_pump(), mimetype="text/event-stream")
-    response.headers["Cache-Control"] = "no-cache"
+    response.headers["Cache-Control"] = "no-store"
     # prevent reverse proxy from buffering messages
     response.headers["X-Accel-Buffering"] = "no"
     return response

--- a/blueprints/main.py
+++ b/blueprints/main.py
@@ -1,16 +1,42 @@
-from flask import Blueprint, render_template
+import time
+
+from flask import Blueprint, render_template, make_response, request, session
 from markdown import markdown
+from werkzeug.http import parse_etags
 
+import cache
 from model.Firehose import Firehose
-
+from model.Slip import get_slip_bitmask
+from shared import app
 
 main_blueprint = Blueprint('main', __name__, template_folder='template')
 
 
 @main_blueprint.route("/")
 def index():
+    cache_connection = cache.Cache()
+    current_theme = session.get("theme") or app.config.get("DEFAULT_THEME") or "stock"
+    response_cache_key = "firehose-%d-%s-render" % (get_slip_bitmask(), current_theme)
+    cached_response_body = cache_connection.get(response_cache_key)
+    etag_value = "%s-%f"  % (response_cache_key, time.time())
+    etag_cache_key = "%s-etag" % response_cache_key
+    if cached_response_body:
+        etag_header = request.headers.get("If-None-Match")
+        if etag_header:
+            parsed_etag = parse_etags(etag_header)
+            current_etag = cache_connection.get(etag_cache_key)
+            if parsed_etag.contains_weak(current_etag):
+                return make_response("", 304)
+        cached_response = make_response(cached_response_body)
+        cached_response.set_etag(etag_value, weak=True)
+        return cached_response
     greeting = open("deploy-configs/index-greeting.html").read()
-    return render_template("index.html", greeting=greeting, threads=Firehose().get_impl())
+    template = render_template("index.html", greeting=greeting, threads=Firehose().get_impl())
+    uncached_response = make_response(template)
+    uncached_response.set_etag(etag_value, weak=True)
+    cache_connection.set(response_cache_key, template)
+    cache_connection.set(etag_cache_key, etag_value)
+    return uncached_response
 
 
 @main_blueprint.route("/rules")

--- a/post.py
+++ b/post.py
@@ -236,5 +236,9 @@ def create_post(thread: Thread, args: dict) -> Post:
 
     publish_thread(thread, post, replies)
     invalidate_posts(thread, replies)
+    # import here to prevent a circular import
+    # TODO: fix circular import with NewPost
+    from thread import invalidate_board_cache
+    invalidate_board_cache(board_id)
 
     return post


### PR DESCRIPTION
This PR adds ETag and multi-level caching support to board catalogs and the firehose. Since neither are updated with regards to thread views, caching is done automatically at the same level regardless of what `CACHE_VIEW_RATIO` is set to.