### PR TITLE
Optimize Dockerfile for container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,26 @@
 FROM ubuntu:20.04 AS dev
 WORKDIR /maniwani
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-# backend dependencies
-RUN apt-get -y --no-install-recommends install python3 python3-pip pipenv 
-# uwsgi, python and associated plugins
-RUN apt-get -y install uwsgi-core uwsgi-plugin-python3 python3-gevent
-# dependencies for Pillow
-RUN apt-get -y install build-essential libjpeg-dev zlib1g-dev libwebp-dev
+# backend dependencies/frontend depndencies/uwsgi, python and associated plugins
+RUN apt-get update && apt-get -y --no-install-recommends install python3 python3-pip \
+	pipenv uwsgi-core uwsgi-plugin-python3 python3-gevent nodejs npm && \
+	rm -rf /var/lib/apt/lists/*
 # install static build of ffmpeg
 COPY build-helpers/ffmpeg_bootstrap.py /maniwani/build-helpers/
 WORKDIR /maniwani/build-helpers
 RUN python3 ffmpeg_bootstrap.py
 WORKDIR /maniwani
-# frontend dependencies
-RUN apt-get -y --no-install-recommends install nodejs npm
 COPY Pipfile /maniwani
 COPY Pipfile.lock /maniwani
 RUN pipenv install --system --deploy
-# remove backend build-time dependencies
-RUN apt-get -y autoremove build-essential gcc-9 libpython3-dev libc6-dev libjpeg-dev zlib1g-dev
 # point MANIWANI_CFG to the devmode config file
 ENV MANIWANI_CFG=./deploy-configs/devmode.cfg
 # build static frontend files
 COPY package.json /maniwani
 COPY package-lock.json /maniwani
-RUN npm install
 COPY Gulpfile.js /maniwani
 COPY scss /maniwani/scss
-RUN npm run gulp
-# remove frontend build-time dependencies
-RUN apt-get -y autoremove npm nodejs
-RUN rm -rf node_modules
+RUN npm install && npm run gulp && rm -rf node_modules
 # copy source files over
 COPY migrations /maniwani/migrations
 COPY *.py /maniwani/


### PR DESCRIPTION
This is a PR meant to address the concerns mentioned in #142 by shrinking the Maniwani container image from ~840MB as of #143 to ~500MB, which is overall 1/3rd of what it used to be as of the closing of #133. This is accomplished via a couple different things:

1. Minimizing the number of `RUN` commands used during package installation, thus saving space by reducing the number of container image layers created
2. Removing installation of unneeded packages, most notably C-based dependencies for Pillow as the binary version of Pillow was getting used all this time anyway (oops), saving space since a C toolchain is no longer installed
3. Passing `--no-install-recommends` to `apt` to ensure unneeded package dependencies never get installed 
4. Clearing the `apt` cache after installing prerequisites (it should be noted that the [official Docker docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) indicate that this isn't necessary due to the official Debian/Ubuntu images doing this anyway, but I noticed a ~30MB difference by including the `rm -rf /var/lib/apt/lists/*` line)
5. Preventing `node_modules` from ever getting written to the container image  

There's still some room for improvement, mostly having to do with installing node. Until the `react-ui` branch gets merged, node is just a build-time dependency for Sass (and even after it closes only developer mode will need it as a build-time dependency, since the server-side React stuff will normally run in a separate container), so a multi-stage build that compiles and copies over the Sass templates could save roughly an additional 100MB for a total container size of about 400MB. Barring freezing-based trickery as mentioned in #142, I suspect 400MB will be the theoretical lower limit for a Maniwani container, as the other big culprit at the moment, `pipenv install`, is all runtime dependencies - and its layer size closely matches a fresh run of the command on my own system (a 119MB virtualenv). I've included the `docker history` output on my system of the new container below for anyone else thinking of where it might be optimized further.

```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
8f9689ff3f7f        15 minutes ago      /bin/sh -c #(nop)  ENTRYPOINT ["sh" "./docke…   0B                  
fd59554806e9        15 minutes ago      /bin/sh -c #(nop)  EXPOSE 5000                  0B                  
2f44cca491de        15 minutes ago      /bin/sh -c python3 bootstrap.py                 122kB               
cebb0286ee22        15 minutes ago      /bin/sh -c #(nop) COPY file:baa4d2886ca8b3a9…   441B                
8f51f3eba8f4        15 minutes ago      /bin/sh -c #(nop) COPY dir:14f0925707a4d1a07…   77.4kB              
efb6df435c3c        15 minutes ago      /bin/sh -c #(nop) COPY dir:aa113877deba96c78…   1.78kB              
124917e14b3b        15 minutes ago      /bin/sh -c #(nop) COPY dir:308330081e7889b90…   38.1kB              
3b22c6775d2e        15 minutes ago      /bin/sh -c #(nop) COPY dir:ca99b38ee8095a613…   3.44kB              
cbaeed8941a6        15 minutes ago      /bin/sh -c #(nop) COPY file:baa4d2886ca8b3a9…   441B                
89753972fe29        15 minutes ago      /bin/sh -c #(nop) COPY dir:1e42d55092b3b6a3c…   22.6kB              
091253c0a5a2        15 minutes ago      /bin/sh -c #(nop) COPY multi:14eabc041a9e767…   39.8kB              
e8c13d70d692        15 minutes ago      /bin/sh -c #(nop) COPY dir:cf5fb332687d76e67…   8.81kB              
c987ace4fbf7        15 minutes ago      /bin/sh -c npm install && npm run gulp && rm…   24MB                
619109c4f1ba        15 minutes ago      /bin/sh -c #(nop) COPY dir:5f930439500dd6dae…   6.42kB              
7811eaada530        15 minutes ago      /bin/sh -c #(nop) COPY file:1609effdf57737ff…   2.06kB              
b3dea746f989        18 minutes ago      /bin/sh -c #(nop) COPY file:255ffd6bd4801309…   216kB               
88c2cc9a7bd2        18 minutes ago      /bin/sh -c #(nop) COPY file:f5ec4cff96292621…   1.02kB              
b1ad7051f892        18 minutes ago      /bin/sh -c #(nop)  ENV MANIWANI_CFG=./deploy…   0B                  
db186e4d457c        18 minutes ago      /bin/sh -c pipenv install --system --deploy     134MB               
b34c5306dd52        19 minutes ago      /bin/sh -c #(nop) COPY file:40ca45c01c9d5a8f…   24.1kB              
a6be3c49ddb2        19 minutes ago      /bin/sh -c #(nop) COPY file:bb275a3cd4bb80bd…   349B                
c89bc3085e01        19 minutes ago      /bin/sh -c #(nop) WORKDIR /maniwani             0B                  
e7aa1fbe7954        19 minutes ago      /bin/sh -c python3 ffmpeg_bootstrap.py          74.1MB              
6bc893712ace        19 minutes ago      /bin/sh -c #(nop) WORKDIR /maniwani/build-he…   0B                  
f2cb64eef83e        19 minutes ago      /bin/sh -c #(nop) COPY file:c8c620f78ba6306c…   917B                
299d36d34c73        19 minutes ago      /bin/sh -c apt-get update && apt-get -y --no…   198MB               
811bc5c7d80e        47 minutes ago      /bin/sh -c #(nop)  ENV DEBIAN_FRONTEND=nonin…   0B                  
871ce448606d        47 minutes ago      /bin/sh -c #(nop) WORKDIR /maniwani             0B                  
1d622ef86b13        6 weeks ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
<missing>           6 weeks ago         /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B                  
<missing>           6 weeks ago         /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   811B                
<missing>           6 weeks ago         /bin/sh -c [ -z "$(apt-get indextargets)" ]     1.01MB              
<missing>           6 weeks ago         /bin/sh -c #(nop) ADD file:a58c8b447951f9e30…   72.8MB              
```