### PR TITLE
docker-slim usage with Maniwani

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,14 @@ WORKDIR /maniwani
 ENV DEBIAN_FRONTEND=noninteractive
 # backend dependencies/frontend depndencies/uwsgi, python and associated plugins
 RUN apt-get update && apt-get -y --no-install-recommends install python3 python3-pip \
-	pipenv uwsgi-core uwsgi-plugin-python3 uwsgi-plugin-gevent-python3 python3-gevent nodejs npm && \
-	rm -rf /var/lib/apt/lists/*
-# install static build of ffmpeg
+	pipenv uwsgi-core uwsgi-plugin-python3 uwsgi-plugin-gevent-python3 python3-gevent nodejs npm
+# install static build of ffmpeg and compress with upx
 COPY build-helpers/ffmpeg_bootstrap.py /maniwani/build-helpers/
 WORKDIR /maniwani/build-helpers
-RUN python3 ffmpeg_bootstrap.py
+RUN python3 ffmpeg_bootstrap.py && apt-get -y install upx-ucl && \
+	chmod +w ../ffmpeg/ffmpeg && \
+	upx -9 ../ffmpeg/ffmpeg && apt-get autoremove -y upx-ucl && \
+	rm -rf /var/lib/apt/lists/*
 WORKDIR /maniwani
 COPY Pipfile /maniwani
 COPY Pipfile.lock /maniwani

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Features
 Installation
 ------------
 
+NOTE: If you build Maniwani with Docker, then it is recommended to use [docker-slim](https://github.com/docker-slim/docker-slim)
+on the resulting container image, which can net approximately a 5x decrease in image size.
+
 ### With Docker - standalone development image
 
 In this directory, run the following to build a development Docker image:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation
 ------------
 
 NOTE: If you build Maniwani with Docker, then it is recommended to use [docker-slim](https://github.com/docker-slim/docker-slim)
-on the resulting container image, which can net approximately a 2.5x decrease in image size. The `build-slim.sh` script included
+on the resulting container image, which can net approximately a 3x decrease in image size. The `build-slim.sh` script included
 in the repository contains the flags needed to successfuly run a slimmed-down container; invoke it instead of using `docker-slim`
 directly.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Installation
 ------------
 
 NOTE: If you build Maniwani with Docker, then it is recommended to use [docker-slim](https://github.com/docker-slim/docker-slim)
-on the resulting container image, which can net approximately a 5x decrease in image size.
+on the resulting container image, which can net approximately a 2.5x decrease in image size. The `build-slim.sh` script included
+in the repository contains the flags needed to successfuly run a slimmed-down container; invoke it instead of using `docker-slim`
+directly.
 
 ### With Docker - standalone development image
 

--- a/build-helpers/captchouli/Dockerfile
+++ b/build-helpers/captchouli/Dockerfile
@@ -1,10 +1,8 @@
 FROM debian:buster-slim
-# install prereqs
-RUN apt-get update
-RUN apt-get install -y golang libopencv-dev
-RUN apt-get install -y git
-# grab utils for bootstrapping watcher
-RUN apt-get install -y netcat-openbsd psmisc
+# install prereqs, utils for bootstrapping watcher
+RUN apt-get update && apt-get install -y golang libopencv-dev git \
+	netcat-openbsd psmisc && \
+	rm -rf /var/lib/apt/lists/*
 # make a new user so we don't run as root
 RUN useradd -r captchouli
 WORKDIR /home/captchouli

--- a/build-helpers/captchouli/README.md
+++ b/build-helpers/captchouli/README.md
@@ -10,6 +10,14 @@ Quickstart
 	docker build . -t captchouli
 	docker run -p 8512:8512 captchouli
 
+If you have [docker-slim](https://github.com/docker-slim/docker-slim) installed you can also run
+the following, assuming you passed `-t captchouli` to `docker build`:
+
+	./build-slim.sh captchouli
+	
+This will generate a significantly smaller image named `captchouli.slim`, around 300MB compared
+to the 1.5GB image created by `docker build`.
+
 There is also a `bootstrap` option that waits for captchouli to build an initial database before
 stopping the container, which can prove very useful; building the database for the first time can potentially
 take a while:

--- a/build-helpers/captchouli/build-slim.sh
+++ b/build-helpers/captchouli/build-slim.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+docker-slim build --include-shell --include-bin /home/captchouli/go/bin/captchouli \
+			--include-bin /bin/sleep --include-bin /bin/nc --include-bin /bin/killall \
+			"$@" 

--- a/build-slim.sh
+++ b/build-slim.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# explanation of the included files:
+# cacert.pem - certs for requests
+# PIL/Pillow.libs - plugins/shared objects needed by Pillow, easier to include them
+# this way than to create a crafted HTTP request to get them all
+# fractions.py - module needed by Pillow's JPEG plugin
+# xml/html5lib - packages needed by bleach
+# gevent - gevent is partially included thanks to the default probe but misses some things
+# ffmpeg - missed by the probe (a probe request could be crafted to grab it but would need video)
+# maniwani/* - folders either missed entirely by the default HTTP probe or only partially included
+docker-slim build --include-shell \
+			--include-path /usr/local/lib/python3.8/dist-packages/certifi/cacert.pem \
+			--include-path /usr/local/lib/python3.8/dist-packages/PIL \
+			--include-path /usr/local/lib/python3.8/dist-packages/Pillow.libs \
+			--include-path /usr/lib/python3.8/fractions.py \
+			--include-path /usr/lib/python3.8/xml \
+			--include-path /usr/local/lib/python3.8/dist-packages/bleach/_vendor/html5lib \
+			--include-path /usr/local/lib/python3.8/dist-packages/gevent \
+			--include-path /maniwani/ffmpeg \
+			--include-path /maniwani/templates \
+			--include-path /maniwani/static \
+			--include-path /maniwani/migrations \
+			--include-path /maniwani/uploads \
+			"$@"


### PR DESCRIPTION
This PR adds a note in the README on how [docker-slim](https://github.com/docker-slim/docker-slim) can be used with Maniwani. Ideally, docker-slim is integrated as part of the build process of Maniwani itself, but it's not clear at the moment on whether or not that can be done automatically.