### PR TITLE
Port CSS away from Bootstrap

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -12,33 +12,8 @@ function clean() {
 function maniwani_css() {
 	return src('./scss/themes/*/theme-*.scss').pipe(
 		sass({outputStyle: 'compressed',
-			  includePaths: ['./node_modules/bootstrap/scss', './scss/base']}).on('error', sass.logError)).pipe(
+			  includePaths: ['./scss/base', './node_modules/bootstrap/scss']}).on('error', sass.logError)).pipe(
 			dest('./static/css/')).pipe(browserSync.stream())
-}
-
-function popper() {
-	return src('./node_modules/popper.js/dist/umd/popper.min.js').pipe(
-		dest('./static/popperjs/umd'))
-}
-
-function jquery() {
-	return src('./node_modules/jquery/dist/jquery.min.js').pipe(
-		dest('./static/jquery/'))
-}
-
-function imagesloaded() {
-	return src('./node_modules/imagesloaded/imagesloaded.pkgd.min.js').pipe(
-		dest('./static/imagesloaded/'))
-}
-
-function masonry() {
-	return src('./node_modules/masonry-layout/dist/masonry.pkgd.min.js').pipe(
-		dest('./static/masonry/'))
-}
-
-function bootstrap_js() {
-	return src('./node_modules/bootstrap/dist/js/bootstrap.min.js').pipe(
-		dest('./static/bootstrap/'))
 }
 
 function fontawesome_css() {
@@ -49,6 +24,16 @@ function fontawesome_css() {
 function fontawesome_webfonts() {
 	return src('./node_modules/@fortawesome/fontawesome-free/webfonts/fa-solid-900.+(ttf|woff|woff2)').pipe(
 		dest('./static/webfonts/'))
+}
+
+function firasans_webfonts_index() {
+	return src(['./node_modules/fontsource-fira-sans/index.css', ]).pipe(
+		dest('./static/webfonts/firasans/'))
+}
+
+function firasans_webfonts_woff() {
+	return src('./node_modules/fontsource-fira-sans/files/*').pipe(
+		dest('./static/webfonts/firasans/files'))
 }
 
 function watch() {
@@ -64,7 +49,6 @@ function watch() {
 exports.watch = watch
 exports.clean = clean
 exports.css = parallel(maniwani_css, fontawesome_css)
-exports.fonts = fontawesome_webfonts
-exports.js = parallel(popper, jquery, bootstrap_js, imagesloaded, masonry)
-exports.build = series(clean, parallel(exports.css, exports.js, exports.fonts))
+exports.fonts = parallel(fontawesome_webfonts, firasans_webfonts_index, firasans_webfonts_woff)
+exports.build = series(clean, parallel(exports.css, exports.fonts))
 exports.default = exports.build

--- a/frontend/src/components/Catalog.jsx
+++ b/frontend/src/components/Catalog.jsx
@@ -16,27 +16,19 @@ function ThreadThumbnail(props) {
         }
     }
     var imageClass = props.spoiler? "catalog-thumbnail thumbnail-spoiler" : "catalog-thumbnail";
-    // TODO: use CSS to space the board display instead of a space character
     return (
         <a href={props.thread_url} className={"thread " + bgStyle}>
           <div className="catalog-media-container">
             {props.spoiler && <span className="spoiler-label text-danger">!</span>}
             <img className={imageClass} src={props.thumb_url}/>
           </div>
-          <div className="p-1">
-            {props.subject && <h6 className={"text-center font-weight-bold " + textStyle}>{props.subject}</h6>}
-            {!props.subject && <h6 className="text-center text-muted">No subject</h6>}
-          </div>
-          <div className="pb-2 pl-4 pr-4">
-            <div className={"thread-body " + textStyle} dangerouslySetInnerHTML={{__html: props.body}}>
-            </div>
-          </div>
+          {props.subject && <span className={"thread-subject"}>{props.subject || "No subject"}</span>}
+          <div className={"thread-body " + textStyle} dangerouslySetInnerHTML={{__html: props.body}}/>
           <span className={"thread-stats-container " + textStyle}>
             {props.display_board && <small>/</small>}
             {props.display_board && <small>{props.board}</small>}
             {props.display_board && (<small>/ </small>)}
             <i className="fas fa-comment"></i>{props.num_replies}
-            &nbsp;
             <i className="fas fa-image"></i>{props.num_media}
           </span>
         </a>
@@ -49,7 +41,7 @@ function mapStateToProps(state) {
 
 function Catalog(props) {
     return (
-        <div className="container-fluid">
+        <div className="container">
           <div className="catalog-grid">
             {props.threads.map((thread, i) => {
                 return <ThreadThumbnail {...thread} display_board={props.display_board} tag_styles={props.tag_styles}/>;

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react';
 import TimeAgo from 'react-timeago';
 
 function getThumbClass(spoiler) {
-    return spoiler? "thread-thumbnail thumbnail-spoiler" : "thread-thumbnail";
+    return spoiler? "post-thumbnail thumbnail-spoiler" : "post-thumbnail";
 }
 
 function GenericThumbnail(props) {
@@ -133,26 +133,25 @@ export default function Post(props) {
                          </div>
                        </div>}
             <div className="row">
-              <div className="col-auto">
+              <div className="col">
                 <small className="text-secondary">Poster:</small>
                 <small className="text-info">{props.poster}</small>
                 {props.slip && props.slip.is_admin && <span className="badge badge-danger">Admin</span>}
                 {props.slip && !props.slip.is_admin && props.slip.is_mod && <span className="badge badge-success">Mod</span>}
               </div>
-              <div className="col-auto">
+              <div className="col">
                 <small className="text-secondary">Posted: </small>
                 {onClient && <small className="text-info"><TimeAgo date={props.datetime}/></small>}
                 {!onClient && <small className="text-info">{props.datetime}</small>}
               </div>
-              <div className="col-auto">
+              <div className="col">
                 <small className="text-secondary">Post #:</small>
                 <small className="text-info">{props.id}</small>
               </div>
-              <div className="w-100 d-block d-md-none"></div>
-              <div className="col-auto">
+              <div className="col">
                 <small><a className="badge badge-primary" href={"#" + props.id}>Permalink</a></small>
               </div>
-              {props.slip && (props.slip.is_admin || props.slip.is_mod) && <div className="col-auto">
+              {props.slip && (props.slip.is_admin || props.slip.is_mod) && <div className="col">
                                     <details className="badge badge-danger">
                                       <summary>Moderation</summary>
                                       {props.is_op && <a className="mod-item" href={props.move_url}>Move</a>}
@@ -161,7 +160,7 @@ export default function Post(props) {
                                   </div>}
             </div>
             {props.replies.length > 0 && <div className="row">
-                                          <div className="col-auto">
+                                          <div className="col">
                                             <ReplyList replies={props.replies}/>
                                           </div>
                                         </div>}

--- a/frontend/src/components/Thread.jsx
+++ b/frontend/src/components/Thread.jsx
@@ -8,11 +8,11 @@ function mapStateToProps(state) {
 
 function Thread(props) {
     return (
-        <div className="container">
+        <React.Fragment>
           {props.posts.map((post, i) => {
               return <Post {...post}/>;
           })}
-        </div>
+        </React.Fragment>
     );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -593,11 +593,6 @@
         "inherits": "~2.0.0"
       }
     },
-    "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1229,11 +1224,6 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
-    "desandro-matches-selector": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz",
-      "integrity": "sha1-cXvu1NwT59jzdi9wem1YpndCGOE="
-    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1497,11 +1487,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "ev-emitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
-      "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -1880,14 +1865,6 @@
         "parse-filepath": "^1.0.1"
       }
     },
-    "fizzy-ui-utils": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.7.tgz",
-      "integrity": "sha512-CZXDVXQ1If3/r8s0T+v+qVeMshhfcuq0rqIFgJnrtd+Bu8GmDmqMjntjUePypVtjHXKJ6V4sw9zeyox34n9aCg==",
-      "requires": {
-        "desandro-matches-selector": "^2.0.0"
-      }
-    },
     "flagged-respawn": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
@@ -1929,6 +1906,11 @@
           "dev": true
         }
       }
+    },
+    "fontsource-fira-sans": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fontsource-fira-sans/-/fontsource-fira-sans-3.0.5.tgz",
+      "integrity": "sha512-LqowFtPxup23alt9yvrMe9IWs01ue3Jfbw63VJm+RPl+mUJQjnwzJZXNHwwZtL3jOheqvCwVy5CJwLVPR27g2g=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2622,11 +2604,6 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
-    "get-size": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.3.tgz",
-      "integrity": "sha512-lXNzT/h/dTjTxRbm9BXb+SGxxzkm97h/PCIKtlN/CBCxxmkkIVV21udumMS93MuVTDX583gqc94v3RjuHmI+2Q=="
-    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -3165,14 +3142,6 @@
       "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
       "dev": true
     },
-    "imagesloaded": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.4.tgz",
-      "integrity": "sha512-ltiBVcYpc/TYTF5nolkMNsnREHW+ICvfQ3Yla2Sgr71YFwQ86bDwV9hgpFhFtrGPuwEx5+LqOHIrdXBdoWwwsA==",
-      "requires": {
-        "ev-emitter": "^1.0.0"
-      }
-    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -3488,11 +3457,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
-    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -3735,15 +3699,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "masonry-layout": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-4.2.2.tgz",
-      "integrity": "sha512-iGtAlrpHNyxaR19CvKC3npnEcAwszXoyJiI8ARV2ePi7fmYhIud25MHK8Zx4P0LCC4d3TNO9+rFa1KoK1OEOaA==",
-      "requires": {
-        "get-size": "^2.0.2",
-        "outlayer": "^2.1.0"
       }
     },
     "matchdep": {
@@ -4259,16 +4214,6 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "outlayer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.1.tgz",
-      "integrity": "sha1-KYY7beEOpdrf/8rfoNcokHOH6aI=",
-      "requires": {
-        "ev-emitter": "^1.0.0",
-        "fizzy-ui-utils": "^2.0.0",
-        "get-size": "^2.0.2"
-      }
-    },
     "p-map": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -4437,11 +4382,6 @@
         "arr-union": "^3.1.0",
         "extend-shallow": "^3.0.2"
       }
-    },
-    "popper.js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
     },
     "portscanner": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
-    "bootstrap": "^4.4.1",
-    "imagesloaded": "^4.1.4",
-    "jquery": "^3.5.0",
-    "masonry-layout": "^4.2.2",
-    "popper.js": "^1.16.0"
+    "fontsource-fira-sans": "^3.0.5"
   }
 }

--- a/scss/base/base.scss
+++ b/scss/base/base.scss
@@ -1,0 +1,10 @@
+@import "baseline";
+@import "board-index";
+@import "captchouli";
+@import "catalog";
+@import "container";
+@import "forms";
+@import "media-grid";
+@import "navbar";
+@import "post";
+@import "styling";

--- a/scss/base/baseline.scss
+++ b/scss/base/baseline.scss
@@ -1,0 +1,27 @@
+body {
+	margin: 0;
+	font-family: "Fira Sans, sans-serif";
+}
+
+.row {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.col {
+	width: auto;
+	padding-left: 15px;
+	padding-right: 15px;
+}
+
+.page-footer {
+	text-align: center;
+}
+
+.btn {
+	border: none;
+	padding: 10px 25px;
+	font-size: 1rem;
+	margin: 0.25rem;
+	cursor: pointer;
+}

--- a/scss/base/board-index.scss
+++ b/scss/base/board-index.scss
@@ -1,5 +1,4 @@
 .board-label {
-	@extend .text-dark;
 	font-size: 4em;
 	position: absolute;
 	top: 50%;
@@ -10,6 +9,5 @@
 .board-entry {
 	@extend .media-element;
 	position: relative;
-	background-color: var(--gray);
 	background-blend-mode: screen;
 }

--- a/scss/base/catalog.scss
+++ b/scss/base/catalog.scss
@@ -1,26 +1,26 @@
 .thread {
-	@extend .border;
-	@extend .rounded;
 	width: 300px;
 	height: 300px;
 	position: relative;
 	overflow: hidden;
-}
-.thread:hover {
-	text-decoration: none !important;
+	text-decoration: none;
+	padding: 10px;
 }
 .thread-body {
-	font-size: 0.7em;
+	margin-left: 1rem;
+	margin-right: 1rem;
+}
+.thread-subject {
+	display: block;
+	font-weight: bold;
+	text-align: center;
 }
 .catalog-grid {
 	display: grid;
-	justify-content: center;
-	grid-gap: 30px;
+	grid-gap: 90px;
 	grid-template-columns: repeat(auto-fill, 300px);
 }
 .catalog-media-container {
-	@extend .p-2;
-	@extend .mx-2;
 	position: relative;
 	overflow: hidden;
 	display: flex;
@@ -32,8 +32,7 @@
 	height: 125px;
 }
 .thread-stats-container {
-	@extend .p-1;
 	position: absolute;
-	bottom: 0;
-	right: 0;
+	bottom: 5px;
+	right: 10px;
 }

--- a/scss/base/container.scss
+++ b/scss/base/container.scss
@@ -1,0 +1,4 @@
+.container {
+	margin: auto;
+	max-width: 80%;
+}

--- a/scss/base/forms.scss
+++ b/scss/base/forms.scss
@@ -1,0 +1,13 @@
+.form-control {
+	width: 100%;
+}
+
+.form-group > label {
+	margin-bottom: 0.25rem;
+	display: inline-block;
+	margin-top: 0.25rem;
+}
+
+.form-group > [type="file"] {
+	display: block;
+}

--- a/scss/base/media-grid.scss
+++ b/scss/base/media-grid.scss
@@ -6,7 +6,6 @@
 }
 
 .media-element {
-	@extend .img-thumbnail;
 	height: 250px;
 	background-position: center;
 	background-repeat: no-repeat;

--- a/scss/base/navbar.scss
+++ b/scss/base/navbar.scss
@@ -1,4 +1,21 @@
 .navbar {
-	@extend .navbar-dark;
-	@extend .bg-dark;
+	display: flex;
+	position: sticky;
+	z-index: 1;
+	top: 0;
+	flex-flow: row nowrap;
+	justify-content: flex-start;
+}
+
+.navbar-site-name {
+	margin-right: 1rem;
+	font-size: 1.25rem;
+	text-decoration: none;
+	margin-top: 0.25rem;
+	margin-left: 0.25rem;
+}
+
+.navbar-link {
+	padding: 0.5rem;
+	text-decoration: none;
 }

--- a/scss/base/post.scss
+++ b/scss/base/post.scss
@@ -1,27 +1,11 @@
-.post-container {
-	@extend .row;
-	@extend .pt-2;
-}
-
-.post-container:nth-child(odd) {
-	background-color: #e7e7e7;
-}
-.post-container:nth-child(even) {
-	background-color: var(--white);
-}
-
-.reply-container {
-	background-color: var(--white);
-}
-
 .post-replies {
 	display: inline;
 }
 
-.thread-thumbnail {
-	@extend .img-thumbnail;
+.post-thumbnail {
 	display: inline-block;
 	overflow: hidden;
 	max-width: 15em;
 	max-height: 20em;
+	margin-top: 8px;
 }

--- a/scss/base/styling.scss
+++ b/scss/base/styling.scss
@@ -24,8 +24,4 @@ blockquote {
 }
 .mod-item {
 	display: block;
-	@extend .w-100;
-	@extend .my-1;
-	@extend .badge;
-	@extend .badge-primary;
 }

--- a/scss/themes/stock/theme-stock.scss
+++ b/scss/themes/stock/theme-stock.scss
@@ -1,8 +1,75 @@
-@import "bootstrap";
-@import "media-grid";
-@import "board-index";
-@import "catalog";
-@import "post";
-@import "styling";
-@import "captchouli";
-@import "navbar";
+@import "base";
+
+body {
+	margin: 0;
+	font-family: "Fira Sans";
+	background-color: #f8f9fa;
+	color: #212529;
+}
+
+p {
+	max-width: 90ch;
+}
+
+.lead {
+	font-size: 1.25rem;
+}
+
+.navbar {
+	background-color: #f8f9fa;
+}
+
+
+.navbar-link {
+	color: #212529;
+}
+
+.navbar-site-name {
+	color: #212529;
+}
+
+.thread {
+	background-color: #dee2e6;
+	color: #212529;
+}
+
+.thread-stats-container {
+	color: #868e96;
+}
+
+.text-secondary {
+	color: #868e96;
+}
+
+.post-container {
+	margin-bottom: 1rem;
+	background-color: #dee2e6;
+	margin-top: 1rem;
+}
+
+.board-entry {
+	background-color:  #868e96;
+}
+
+.board-label {
+	color: #212529;	
+}
+
+.btn {
+	color: #f8f9fa;
+}
+
+.btn-primary {
+	background-color: #868e96;
+}
+
+.btn-primary:hover {
+	background-color: #495057
+}
+
+.btn-secondary {
+	background-color: #343a40;
+}
+.btn-secondary:hover {
+	background-color: #212529;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,50 +6,32 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 	<link rel="stylesheet" href="{{ get_current_theme_path() }}">
-    <script src="{{ static_resource("jquery/jquery.min.js") }}"></script>
-    <script src="{{ static_resource("popperjs/umd/popper.min.js") }}"></script>
-    <script src="{{ static_resource("bootstrap/bootstrap.min.js") }}"></script>
 
     <!-- Fontawesome -->
     <link rel="stylesheet" href="{{ static_resource("fontawesome/all.min.css") }}">
+
+	<!-- Fira Sans -->
+	<link rel="stylesheet" href="{{ static_resource("webfonts/firasans/index.css") }}">
+	
 	{% block head %}{% endblock %}
     <title>{{ instance_name() }} - {% block title %}{% endblock %}</title>
 </head>
 <body>
-<nav class="navbar navbar-expand-lg sticky-top mb-2">
-    <a class="navbar-brand" href="{{ url_for("main.index") }}">{{ instance_name() }}</a>
-    <script>
-			 document.write('<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-nav"> \
-				 <span class="navbar-toggler-icon"></span> \
-				 </button>')
-
-
-
-    </script>
-    <div id="site-nav" class="navbar-nav">
+	<nav class="navbar">
+		<a class="navbar-site-name" href="{{ url_for("main.index") }}">{{ instance_name() }}</a>
         {% block navbar %}{% endblock %}
 		{% if board is defined %}
-			<a href="{{ url_for("boards.catalog", board_id=board["id"]) }}" class="nav-item nav-link">/{{ board["name"] }}/ Catalog</a>
+			<a href="{{ url_for("boards.catalog", board_id=board["id"]) }}" class="navbar-link">/{{ board["name"] }}/ Catalog</a>
 		{% endif %}
-        <a href="{{ url_for("boards.list") }}" class="nav-item nav-link">Boards</a>
-        <a href="{{ url_for("slip.landing") }}" class="nav-item nav-link">Slip</a>
+        <a href="{{ url_for("boards.list") }}" class="navbar-link">Boards</a>
+        <a href="{{ url_for("slip.landing") }}" class="navbar-link">Slip</a>
         {% if board is not defined %}
-        <a href="{{ url_for("main.rules") }}" class="nav-item nav-link">Rules</a>
+			<a href="{{ url_for("main.rules") }}" class="navbar-link">Rules</a>
         {% else %}
-        <a href="{{ url_for("boards.rules", board_id=board.id) }}" class="nav-item nav-link">Rules</a>
+			<a href="{{ url_for("boards.rules", board_id=board.id) }}" class="navbar-link">Rules</a>
         {% endif %}
-        <a href="{{ url_for("main.faq") }}" class="nav-item nav-link">FAQ</a>
-        <div class="navbar-nav ml-auto">
-            {% block navbar_right %}{% endblock %}
-        </div>
-    </div>
-    <script>
-				$("#site-nav").addClass("collapse navbar-collapse")
-
-
-
-    </script>
-</nav>
+        <a href="{{ url_for("main.faq") }}" class="navbar-link">FAQ</a>
+	</nav>
 {% with flashes = get_flashed_messages() %}
 {% if flashes %}
 <div class="container">
@@ -77,11 +59,9 @@
 		<button id="theme-submit" type="submit" class="btn btn-primary">Select theme</button>
 	</form>
 </div>
-<div class="container-fluid">
+<div class="page-footer">
     {% block footer %}{% endblock %}
-    <p class="text-center text-muted">
-        <small>Powered by <a href="https://github.com/DangerOnTheRanger/maniwani">Maniwani</a>!</small>
-    </p>
+    <small>Powered by <a href="https://github.com/DangerOnTheRanger/maniwani">Maniwani</a>!</small>
 </div>
 </body>
 </html>

--- a/templates/react-board-index.html
+++ b/templates/react-board-index.html
@@ -3,7 +3,7 @@
 	board index
 {% endblock %}
 {% block content %}
-	<div class="container-fluid">
+	<div class="container">
 		TEMPLATE_CONTENT
 	</div>
 {% endblock %}

--- a/templates/react-catalog.html
+++ b/templates/react-catalog.html
@@ -10,9 +10,9 @@
 	</script>
 {% endblock %}
 {% block navbar %}
-	<a href="{{ url_for("threads.new", board_id=board_id) }}" id="newThreadLink" class="nav-item nav-link">New thread</a>
+	<a href="{{ url_for("threads.new", board_id=board_id) }}" id="newThreadLink" class="navbar-link">New thread</a>
 	{% if get_slip() and get_slip().is_admin %}
-		<a href="{{ url_for("boards.admin", board_id=board_id) }}" class="nav-item nav-link">Admin</a>
+		<a href="{{ url_for("boards.admin", board_id=board_id) }}" class="navbar-link">Admin</a>
 	{% endif %}
 {% endblock %}
 {% block content %}

--- a/templates/react-gallery.html
+++ b/templates/react-gallery.html
@@ -3,10 +3,10 @@
 	media gallery
 {% endblock %}
 {% block navbar %}
-	<a href="{{ url_for("threads.view", thread_id=thread_id) }}" class="nav-item nav-link">Back to thread</a>
+	<a href="{{ url_for("threads.view", thread_id=thread_id) }}" class="navbar-link">Back to thread</a>
 {% endblock %}
 {% block content %}
-	<div class="container-fluid">
+	<div class="container">
 		<div id="gallery-root">
 			TEMPLATE_CONTENT
 		</div>

--- a/templates/react-new-post.html
+++ b/templates/react-new-post.html
@@ -3,7 +3,7 @@
 	reply to thread
 {% endblock %}
 {% block navbar %}
-	<a href="{{ url_for("threads.view", thread_id=thread_id) }}" class="nav-item nav-link">Back to thread</a>
+	<a href="{{ url_for("threads.view", thread_id=thread_id) }}" class="navbar-link">Back to thread</a>
 {% endblock %}
 {% block content %}
 	<div class="container">

--- a/templates/react-thread.html
+++ b/templates/react-thread.html
@@ -30,11 +30,11 @@
 	</script>
 {% endblock %}
 {% block navbar %}
-	<a id="newPostLink" href="{{ url_for("threads.new_post", thread_id=thread_id) }}" class="nav-item nav-link">New post</a>
-	<a href="{{ url_for("threads.view_gallery", thread_id=thread_id) }}" class="nav-item nav-link">Gallery</a>
+	<a id="newPostLink" href="{{ url_for("threads.new_post", thread_id=thread_id) }}" class="navbar-link">New post</a>
+	<a href="{{ url_for("threads.view_gallery", thread_id=thread_id) }}" class="navbar-link">Gallery</a>
 {% endblock %}
 {% block content %}
-	<div class="container-fluid">
+	<div class="container">
 		<div id="thread-container">
 TEMPLATE_CONTENT
 		</div>


### PR DESCRIPTION
This PR fixes #163 by removing any dependency on Bootstrap and some associated stuff like JQuery. In terms of design, the aim is to keep Maniwani with roughly the same look as before, but with some modifications made to distance the project from Bootstrap a bit. For instance, this is what viewing a thread on the ported stock theme looks like as of the first commit in the PR:

![Thread](https://imgur.com/DHosQIl.jpg)

The remaining work before this can be merged is:

* [ ] Port the harajuku theme, re-examine the color palette to come up with something a little more cohesive and easier on the eyes
* [ ] Port the wildride theme
* [ ] Add a new Tomorrow-based theme (call it 明日/Ashita perhaps?)
* [ ] Style moderation tools/dropdown